### PR TITLE
Fix 'See Photos' link for hyphenated registrations

### DIFF
--- a/public_html/script.js
+++ b/public_html/script.js
@@ -1378,7 +1378,7 @@ function getFlightAwareModeSLink(code, ident, linkText) {
 
 function getFlightAwarePhotoLink(registration) {
     if (registration !== null && registration !== "") {
-        return "<a target=\"_blank\" href=\"https://flightaware.com/photos/aircraft/" + registration.trim() + "\">See Photos</a>";
+        return "<a target=\"_blank\" href=\"https://flightaware.com/photos/aircraft/" + registration.replace(/[^0-9a-z]/ig,'') + "\">See Photos</a>";
     }
 
     return "";   


### PR DESCRIPTION
This fixes the 'See Photos' link for hyphenated registrations, which is currently broken. \W would probably work for the regex, but I wanted to make it as narrow as possible.