### PR TITLE
Parallelise the history JSON loads for faster initial load times.

### DIFF
--- a/public_html/script.js
+++ b/public_html/script.js
@@ -381,7 +381,7 @@ function end_load_history() {
                 // Process history
                 for (var h = 0; h < PositionHistoryBuffer.length; ++h) {
                         now = PositionHistoryBuffer[h].now;
-                        console.log("Applying history " + h + 1 + "/" + PositionHistoryBuffer.length + " at: " + now);
+                        console.log("Applying history " + (h + 1) + "/" + PositionHistoryBuffer.length + " at: " + now);
                         processReceiverUpdate(PositionHistoryBuffer[h]);
 
                         // update track


### PR DESCRIPTION
Currently the history load code waits for each file to be returned before requesting the next. This modification requests all files at the same time and keeps count of how many are returned. Once they're all back, end_load_history is called as normal. Any files which fail to load are ignored, rather than stopping the load at the point.

Also correct the "applying history" error message to match the counter against the total - previously it finished with "119/120" because the files are numbered from 0.

As a by-product, for my test server using http/2 this halved the load time against the same code using http/1.1 due to the protocol's improvements in parallel resource loads.