### PR TITLE
Update BLCF & E170 icons

### DIFF
--- a/public_html/markers.js
+++ b/public_html/markers.js
@@ -101,7 +101,7 @@ var TypeDesignatorIcons = {
         'B74D': 'heavy_4e',
         'B74S': 'heavy_4e',
         'B74R': 'heavy_4e',
-        'BLCF': 'heavy_2e',
+        'BLCF': 'heavy_4e',
         'BSCA': 'heavy_4e', // hah!
         'B748': 'heavy_4e',
 
@@ -110,7 +110,6 @@ var TypeDesignatorIcons = {
         'B773': 'heavy_2e',
         'B77L': 'heavy_2e',
 
-        'E170': 'jet_swept',
         'E45X': 'jet_swept',
         'B712': 'jet_swept',
         'C650': 'jet_swept',


### PR DESCRIPTION
BLCF is a a derivative of the B744, so it needs the heavy_4e icon
E170 has wing mounted engines, so removing the override lets it fall through to L2J-M, which uses the more appropriate airliner icon