### PR TITLE
use correct type for bladerf_get_frequency

### DIFF
--- a/sdr_bladerf.c
+++ b/sdr_bladerf.c
@@ -102,7 +102,7 @@ static void show_config()
     int status;
 
     unsigned rate;
-    unsigned freq;
+    bladerf_frequency freq;
     bladerf_lpf_mode lpf_mode;
     unsigned lpf_bw;
     bladerf_lna_gain lna_gain;


### PR DESCRIPTION
Building against ubuntu bionic (amd64) resulted in the following error:

```
    sdr_bladerf.c: In function 'show_config':
    sdr_bladerf.c:116:76: error: passing argument 3 of 'bladerf_get_frequency' from incompatible pointer type [-Werror=incompatible-pointer-types]
             (status = bladerf_get_frequency(BladeRF.device, BLADERF_MODULE_RX, &freq)) < 0 ||
                                                                                ^
    In file included from sdr_bladerf.c:23:0:
    /usr/include/libbladeRF.h:1117:15: note: expected 'bladerf_frequency * {aka long unsigned int *}' but argument is of type 'unsigned int *'
     int CALL_CONV bladerf_get_frequency(struct bladerf *dev,
^~~~~~~~~~~~~~~~~~~~~
```

This commit uses the correct type for the `freq` variable.