### PR TITLE
Multiple updates aimed at improving the Webview part of dump1090

### DIFF
--- a/dump1090.h
+++ b/dump1090.h
@@ -288,6 +288,11 @@ struct mag_buf {
     double          mean_power;      // Mean of normalized (0..1) power level
 };
 
+struct json_aircraft_history_entry {
+    char *content;
+    int clen;
+};
+
 // Program global state
 struct {                             // Internal state
     pthread_t       reader_thread;
@@ -365,10 +370,9 @@ struct {                             // Internal state
     int   json_location_accuracy;    // Accuracy of location metadata: 0=none, 1=approx, 2=exact
 
     int   json_aircraft_history_next;
-    struct {
-        char *content;
-        int clen;
-    } json_aircraft_history[HISTORY_SIZE];
+    int   json_history_size;
+    int   json_history_interval;
+    struct json_aircraft_history_entry *json_aircraft_history;
 
     // User details
     double fUserLat;                // Users receiver/antenna lat/lon needed for initial surface location

--- a/net_io.c
+++ b/net_io.c
@@ -1551,10 +1551,10 @@ char *generateReceiverJson(const char *url_path, int *len)
     MODES_NOTUSED(url_path);
 
     // work out number of valid history entries
-    if (Modes.json_aircraft_history[HISTORY_SIZE-1].content == NULL)
+    if (Modes.json_aircraft_history[Modes.json_history_size-1].content == NULL)
         history_size = Modes.json_aircraft_history_next;
     else
-        history_size = HISTORY_SIZE;
+        history_size = Modes.json_history_size;
 
     p += sprintf(p, "{ " \
                  "\"version\" : \"%s\", "
@@ -1589,7 +1589,7 @@ char *generateHistoryJson(const char *url_path, int *len)
     if (sscanf(url_path, "/data/history_%d.json", &history_index) != 1)
         return NULL;
 
-    if (history_index < 0 || history_index >= HISTORY_SIZE)
+    if (history_index < 0 || history_index >= Modes.json_history_size)
         return NULL;
 
     if (!Modes.json_aircraft_history[history_index].content)

--- a/public_html/planeObject.js
+++ b/public_html/planeObject.js
@@ -138,7 +138,7 @@ PlaneObject.prototype.isFiltered = function() {
 PlaneObject.prototype.updateTrack = function(estimate_time) {
         if (!this.position)
                 return false;
-        if (this.position == this.prev_position)
+        if (this.prev_position && this.position[0] == this.prev_position[0] && this.position[1] == this.prev_position[1])
                 return false;
 
         var projHere = ol.proj.fromLonLat(this.position);
@@ -187,7 +187,7 @@ PlaneObject.prototype.updateTrack = function(estimate_time) {
                         this.history_size += 2;
                 } else {
                         // Keep appending to the existing dashed line; keep every point
-                        lastseg.fixed.appendCoordinate(projPrev);
+                        lastseg.fixed.appendCoordinate(projHere);
                         lastseg.head_update = this.last_position_time;
                         this.history_size++;
                 }

--- a/public_html/planeObject.js
+++ b/public_html/planeObject.js
@@ -241,13 +241,13 @@ PlaneObject.prototype.updateTrack = function(receiver_timestamp, last_timestamp)
         }
         
         // Add more data to the existing track.
-        // We only retain some historical points, at 5+ second intervals,
+        // We only retain some historical points, at 4+ second intervals,
         // plus the most recent point
-        if (this.last_position_time - lastseg.tail_update >= 5) {
+        if (this.last_position_time - lastseg.tail_update >= 4) {
                 // enough time has elapsed; retain the last point and add a new one
                 //console.log(this.icao + " retain last point");
                 lastseg.fixed.appendCoordinate(projHere);
-                lastseg.tail_update = lastseg.head_update;
+                lastseg.tail_update = this.last_position_time;
                 this.history_size ++;
         }
 

--- a/public_html/planeObject.js
+++ b/public_html/planeObject.js
@@ -211,7 +211,7 @@ PlaneObject.prototype.updateTrack = function(estimate_time) {
         }
         
         if ( (lastseg.ground && this.altitude !== "ground") ||
-             (!lastseg.ground && this.altitude === "ground") || this.altitude !== lastseg.altitude ) {
+             (!lastseg.ground && this.altitude === "ground") || Math.abs(this.altitude - lastseg.altitude) >= 250 ) {
                 //console.log(this.icao + " ground state changed");
                 // Create a new segment as the ground state changed.
                 // assume the state changed halfway between the two points

--- a/public_html/planeObject.js
+++ b/public_html/planeObject.js
@@ -232,18 +232,18 @@ PlaneObject.prototype.updateTrack = function(receiver_timestamp, last_timestamp)
         if ( (lastseg.ground && this.altitude !== "ground") ||
              (!lastseg.ground && this.altitude === "ground") || Math.abs(this.altitude - lastseg.altitude) >= 250 ) {
                 //console.log(this.icao + " ground state changed");
-                // Create a new segment as the ground state changed.
-                // assume the state changed halfway between the two points
-                // FIXME needs reimplementing post-google
+                // Create a new segment as the ground state or altitude changed.
+                // New state is only drawn for the track after the state has changed
+                // and we get a new position.
 
-                lastseg.fixed.appendCoordinate(projPrev);
-                this.track_linesegs.push({ fixed: new ol.geom.LineString([projPrev, projHere]),
+                lastseg.fixed.appendCoordinate(projHere);
+                this.track_linesegs.push({ fixed: new ol.geom.LineString([projHere]),
                                            feature: null,
                                            estimated: false,
                                            altitude: this.altitude,
                                            ground: (this.altitude === "ground") });
                 this.append_time = this.last_position_time;
-                this.history_size += 3;
+                this.history_size += 2;
                 return true;
         }
         

--- a/public_html/planeObject.js
+++ b/public_html/planeObject.js
@@ -197,7 +197,10 @@ PlaneObject.prototype.updateTrack = function(receiver_timestamp, last_timestamp)
                         // >5s gap in data, create a new estimated segment
                         //console.log(this.icao + " switching to estimated");
 
-                        lastseg.fixed.appendCoordinate(projPrev);
+                        if (lastseg.fixed.getLastCoordinate()[0] != projPrev[0]) {
+                                lastseg.fixed.appendCoordinate(projPrev);
+                                this.history_size ++;
+                        }
                         this.track_linesegs.push({ fixed: new ol.geom.LineString([projPrev, projHere]),
                                                    feature: null,
                                                    altitude: 0,

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -397,7 +397,7 @@ function load_history_item(i) {
         $("#loader_progress").attr('value',i);
 
         $.ajax({ url: 'data/history_' + i + '.json',
-                 timeout: 5000,
+                 timeout: PositionHistorySize * 40, // Allow 40 ms load time per history entry
                  cache: false,
                  dataType: 'json' })
 

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -441,7 +441,7 @@ function end_load_history() {
                         console.log("Updating tracks at: " + now);
                         for (var i = 0; i < PlanesOrdered.length; ++i) {
                                 var plane = PlanesOrdered[i];
-                                plane.updateTrack((now - last) + 1);
+                                plane.updateTrack(now, last);
                         }
 
                         last = now;
@@ -451,7 +451,7 @@ function end_load_history() {
                 console.log("Final history cleanup pass");
                 for (var i = 0; i < PlanesOrdered.length; ++i) {
                         var plane = PlanesOrdered[i];
-                        plane.updateTick(now);
+                        plane.updateTick(now, last);
                 }
 
                 LastReceiverTimestamp = last;


### PR DESCRIPTION
I've written quite extensive commit logs, please feel free to squash them if they are too much.
The patch using the ground track to decide appending positions to the line segments might be a bit strange but it should work great in practice. At least it does for me. If "show all tracks" is on i can now move the map and scroll when before it was very slow.
The third patch commit log claims a performance improvement which is probably not measurable in practice, i'm not practiced in git enough to change it though.

Regards