### PR TITLE
Remove containment for splitter resizing

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -22,7 +22,7 @@
 		<script type="text/javascript" src="formatter.js?v=2"></script>
 		<script type="text/javascript" src="flags.js"></script>
 		<script type="text/javascript" src="layers.js"></script>
-		<script type="text/javascript" src="script.js?v=2"></script>
+		<script type="text/javascript" src="script.js?v=3"></script>
 		<title>PiAware Skyview</title>
 	</head>
 

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -215,7 +215,6 @@ function initialize() {
 			handles: {
 				s: '#splitter-infoblock'
 			},
-			containment: "#sidebar_container",
 			minHeight: 50
 		});
 


### PR DESCRIPTION
This fixes IE/Edge being unable to increase the size of the panel when first selected