### PR TITLE
Enable lighttpd to listen on IPv6 addresses

### DIFF
--- a/debian/lighttpd/89-dump1090-fa.conf
+++ b/debian/lighttpd/89-dump1090-fa.conf
@@ -12,8 +12,16 @@ url.redirect += (
   "^/dump1090-fa$" => "/dump1090-fa/"
 )
 
-# Listen on port 8080 and serve the map there, too.
+# Listen on Ipv4 port 8080 and serve the map there, too.
 $SERVER["socket"] == ":8080" {
+  alias.url += (
+    "/data/" => "/run/dump1090-fa/",
+    "/" => "/usr/share/dump1090-fa/html/"
+  )
+}
+
+# Listen on IPv6 port 8080 and serve the map there, too.
+$SERVER["socket"] == "[::]:8080" {
   alias.url += (
     "/data/" => "/run/dump1090-fa/",
     "/" => "/usr/share/dump1090-fa/html/"


### PR DESCRIPTION
Currently lighttpd is configured to listen ONLY on IPv4 addresses. Lighttpd should be configured to listen on both IPv4 and IPv6 addresses.