### PR TITLE
Allow build on FreeBSD (and clang)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ifeq ($(RTLSDR), yes)
       LIBS_SDR += -L$(RTLSDR_PREFIX)/lib -lrtlsdr -lusb-1.0
     endif
   else
-    CFLAGS += $(shell pkg-config --cflags librtlsdr)
+    CFLAGS += $(shell pkg-config --cflags-only-I librtlsdr)
     # some packaged .pc files are massively broken, try to handle it
     RTLSDR_LFLAGS := $(shell pkg-config --libs-only-L librtlsdr)
     ifeq ($(RTLSDR_LFLAGS),-L)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ package-wheezy/. Build in there (`dpkg-buildpackage -b`)
 
 The wheezy build does not include bladeRF, HackRF, or LimeSDR support.
 
+## Building on FreeBSD
+
+To build, you will need librtlsdr, pkgconf and GNU Make. For users of pkg(8):
+`pkg install rtl-sdr pkgconf gmake`.
+
+Then proceed by building with `gmake`.
+
 ## Building manually
 
 You can probably just run "make" after installing the required dependencies.

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -18,6 +18,9 @@
 # define le16toh(x) OSSwapLittleToHostInt16(x)
 # define le32toh(x) OSSwapLittleToHostInt32(x)
 
+#elif __FreeBSD__
+#include <sys/endian.h>
+
 #else // other platforms
 
 # include <endian.h>


### PR DESCRIPTION
Some minor changes to allow building on FreeBSD.

Tested on FreeBSD 12.0R on a RPi2 (arm).
