### PR TITLE
Portability fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Binaries are built in the source directory; you will need to arrange to
 install them (and a method for starting them) yourself.
 
 "make BLADERF=no" will disable bladeRF support and remove the dependency on
-libbladeRF.
+libbladeRF. This may be required on some platforms (e.g. MacOS).
 
 "make RTLSDR=no" will disable rtl-sdr support and remove the dependency on
 librtlsdr.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Binaries are built in the source directory; you will need to arrange to
 install them (and a method for starting them) yourself.
 
 "make BLADERF=no" will disable bladeRF support and remove the dependency on
-libbladeRF. This may be required on some platforms (e.g. MacOS).
+libbladeRF. Default is yes on Linux, no on other platforms.
 
 "make RTLSDR=no" will disable rtl-sdr support and remove the dependency on
-librtlsdr.
+librtlsdr. Default is yes.

--- a/compat/clock_gettime/clock_gettime.h
+++ b/compat/clock_gettime/clock_gettime.h
@@ -3,8 +3,16 @@
 
 #include <mach/mach_time.h> // Apple-only, but this isn't inclued on other BSDs
 
+#ifdef __OpenBSD__
 #ifdef _CLOCKID_T_DEFINED_
 #define CLOCKID_T
+#endif
+#endif
+
+#ifdef __APPLE__
+#ifdef CLOCK_MONOTONIC
+#define CLOCKID_T
+#endif
 #endif
 
 #ifndef CLOCKID_T

--- a/compat/clock_nanosleep/clock_nanosleep.h
+++ b/compat/clock_nanosleep/clock_nanosleep.h
@@ -1,8 +1,16 @@
 #ifndef CLOCK_NANOSLEEP_H
 #define CLOCK_NANOSLEEP_H
 
+#ifdef __OpenBSD__
 #ifdef _CLOCKID_T_DEFINED_
 #define CLOCKID_T
+#endif
+#endif
+
+#ifdef __APPLE__
+#ifdef CLOCK_MONOTONIC
+#define CLOCKID_T
+#endif
 #endif
 
 #ifndef CLOCKID_T

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -18,6 +18,9 @@
 # define le16toh(x) OSSwapLittleToHostInt16(x)
 # define le32toh(x) OSSwapLittleToHostInt32(x)
 
+#elif defined(__FreeBSD__)
+#include <sys/endian.h>
+
 #else // other platforms
 
 # include <endian.h>


### PR DESCRIPTION
Fixes building on MacOS (and probably OpenBSD but untested). Commit bef563b8a32862e1c487b4e6678384ea8175dc04 had removed the building of cross-platform compatibility code that exists in the `compat/` folder.

Tested on MacOS 10.14/Mojave, OS X 10.11/El Capitan, and Debian 9/Stretch.

Building with BladeRF would not work for me on Mac, so build using `make BLADERF=no`, at least for now.