### PR TITLE
Overflow fix

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -1550,7 +1550,7 @@ char *generateStatsJson(const char *url_path, int *len) {
     p = appendStatsJson(p, end, &add, "total");
     p = safe_snprintf(p, end, "\n}\n");
 
-    assert(p <= end);
+    assert(p < end);
 
     *len = p-buf;
     return buf;
@@ -1908,7 +1908,7 @@ static void writeFATSVPositionUpdate(float lat, float lon, float alt)
     --p; // remove last tab
     p = safe_snprintf(p, end, "\n");
 
-    if (p <= end)
+    if (p < end)
         completeWrite(&Modes.fatsv_out, p);
     else
         fprintf(stderr, "fatsv: output too large (max %d, overran by %d)\n", TSV_MAX_PACKET_SIZE, (int) (p - end));
@@ -1935,7 +1935,7 @@ static void writeFATSVEventMessage(struct modesMessage *mm, const char *datafiel
     }
     p = safe_snprintf(p, end, "\n");
 
-    if (p <= end)
+    if (p < end)
         completeWrite(&Modes.fatsv_out, p);
     else
         fprintf(stderr, "fatsv: output too large (max %d, overran by %d)\n", TSV_MAX_PACKET_SIZE, (int) (p - end));
@@ -2256,7 +2256,7 @@ static void writeFATSV()
         --p; // remove last tab
         p = safe_snprintf(p, end, "\n");
 
-        if (p <= end)
+        if (p < end)
             completeWrite(&Modes.fatsv_out, p);
         else
             fprintf(stderr, "fatsv: output too large (max %d, overran by %d)\n", TSV_MAX_PACKET_SIZE, (int) (p - end));

--- a/net_io.c
+++ b/net_io.c
@@ -1878,7 +1878,7 @@ __attribute__ ((format (printf,4,5))) static char *appendFATSV(char *p, char *en
     return p;
 }
 
-#define TSV_MAX_PACKET_SIZE 600
+#define TSV_MAX_PACKET_SIZE 800
 #define TSV_VERSION "4E"
 
 static void writeFATSVPositionUpdate(float lat, float lon, float alt)


### PR DESCRIPTION
This PR fixes some errors with piaware reported by users here:
https://discussions.flightaware.com/t/announcing-piaware-3-latest-version-3-6-3/18829/959?u=wiedehopf

The first commit should in most practical situations fix both errors as the overrun should no longer happen.

The second commit is just to ensure that should the TSV packet for some reason grow further no crashes are caused by an overrun.