### PR TITLE
Proper libbladerf1 build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ It is designed to build as a Debian package.
 
 You will need a build of libbladeRF. You can build packages from source:
 
-$ git clone https://github.com/Nuand/bladeRF.git
-$ cd bladeRF
+$ git clone https://github.com/Nuand/bladeRF.git  
+$ cd bladeRF  
+$ git checkout 2017.12-rc1  
 $ dpkg-buildpackage -b
 
 Or Nuand has some build/install instructions including an Ubuntu PPA


### PR DESCRIPTION
The current libbladerf build instructions will build the latest version of libbladerf which is not compatible with dump1090-fa in its current form. This pull request adds an additional command to checkout the 2017.12-rc1 tag before initiating the build process. The resulting packages should then match the version of libbladerf1 which is available in the Stretch package repositories.