### PR TITLE
Skyview: Non-ambiguous date and time formats

### DIFF
--- a/public_html/script.js
+++ b/public_html/script.js
@@ -1190,7 +1190,8 @@ function refreshHighlighted() {
 }
 
 function refreshClock() {
-	$('#clock_div').text(new Date().toLocaleString());
+        var dopt = { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: false };
+        $('#clock_div').text(new Date().toLocaleString(undefined,dopt));
 	var c = setTimeout(refreshClock, 500);
 }
 


### PR DESCRIPTION
This will eliminate ambiguity, while still keeping US folk happy, because currently looking at date like 05/04/2019 no one can tell if it is April on May without additional context (like what browser language is set, what os locale is set, what the software respects - OS locale or browser locale, etc.). And even then don’t assume anything. Good example is my setup, I am US resident and you would expect MM/DD/YYYY on my computers but you will be wrong, as I have my OS locales set to en_GB because that means more internationally compatible date and time formats everywhere. Also I’m from Russia and “middle endian” date breaks my brain everytime.

After patch date will be:

May 4, 2019, 14:07:59 - for US locale
4 May 2019, 14:07:59 - for GB locale

I think it's a good compromise. Anyone who sees this kind of date will know what it is, without knowing what locale browser is set to. Other option is to solely use ISO 8601 without taking any locales into account.

And, of course, we can make change absolutely conservative by just dropping `hour12: false` leaving people who prefer 12hour format happy. But I personally think this is aviation, not granny's kitchen, so 24 hour format is good everywhere.