### PR TITLE
Default configuration improvements

### DIFF
--- a/debian/dump1090-fa.default
+++ b/debian/dump1090-fa.default
@@ -11,5 +11,5 @@ ENABLED=yes
 
 RECEIVER_OPTIONS="--device-index 0 --gain -10 --ppm 0 --net-bo-port 30005"
 DECODER_OPTIONS="--max-range 360"
-NET_OPTIONS="--net --net-heartbeat 60 --net-ro-size 1000 --net-ro-interval 1 --net-ri-port 0 --net-ro-port 30002 --net-sbs-port 30003 --net-bi-port 30004,30104 --net-bo-port 30005"
+NET_OPTIONS="--net --net-heartbeat 60 --net-ro-size 1000 --net-ro-interval 0.1 --net-ri-port 0 --net-ro-port 30002 --net-sbs-port 30003 --net-bi-port 30004,30104 --net-bo-port 30005"
 JSON_OPTIONS="--json-location-accuracy 1"

--- a/debian/dump1090-fa.default
+++ b/debian/dump1090-fa.default
@@ -11,5 +11,5 @@ ENABLED=yes
 
 RECEIVER_OPTIONS="--device-index 0 --gain -10 --ppm 0 --net-bo-port 30005"
 DECODER_OPTIONS="--max-range 360"
-NET_OPTIONS="--net --net-heartbeat 60 --net-ro-size 1000 --net-ro-interval 0.1 --net-ri-port 0 --net-ro-port 30002 --net-sbs-port 30003 --net-bi-port 30004,30104 --net-bo-port 30005"
+NET_OPTIONS="--net --net-heartbeat 60 --net-ro-size 1000 --net-ro-interval 0.1 --net-ri-port 0 --net-ro-port 30002 --net-sbs-port 30003 --net-bi-port 30004,30104"
 JSON_OPTIONS="--json-location-accuracy 1"


### PR DESCRIPTION
I know system clock timestamps are unreliable, but it's unnecessary to add 1 second of jitter to them :)

Having the beast output port set twice in the config file can create confusion when one occurence is changed but has no effect.