### PR TITLE
treewide: Replace usleep with nanosleep

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -660,12 +660,13 @@ int main(int argc, char **argv) {
     if (Modes.sdr_type == SDR_NONE) {
         while (!Modes.exit) {
             struct timespec start_time;
+            struct timespec slp = { 0, 100 * 1000 * 1000};
 
             start_cpu_timing(&start_time);
             backgroundTasks();
             end_cpu_timing(&start_time, &Modes.stats_current.background_cpu);
 
-            usleep(100000);
+            nanosleep(&slp, NULL);
         }
     } else {
         int watchdogCounter = 10; // about 1 second

--- a/faup1090.c
+++ b/faup1090.c
@@ -207,8 +207,9 @@ int main(int argc, char **argv) {
 
     // Run it until we've lost either connection
     while (!Modes.exit && beast_input->connections && fatsv_output->connections) {
+        struct timespec r = { 0, 100 * 1000 * 1000};
         backgroundTasks();
-        usleep(100000);
+        nanosleep(&r, NULL);
     }
 
     return 0;

--- a/view1090.c
+++ b/view1090.c
@@ -212,6 +212,7 @@ int main(int argc, char **argv) {
 
     // Keep going till the user does something that stops us
     while (!Modes.exit) {
+        struct timespec r = { 0, 100 * 1000 * 1000};
         icaoFilterExpire();
         trackPeriodicUpdate();
         modesNetPeriodicWork();
@@ -221,12 +222,12 @@ int main(int argc, char **argv) {
 
         if (s->connections == 0) {
             // lost input connection, try to reconnect
-            usleep(1000000);
+            sleep(1);
             c = serviceConnect(s, bo_connect_ipaddr, bo_connect_port);
             continue;
         }
 
-        usleep(100000);
+        nanosleep(&r, NULL);
     }
 
     interactiveCleanup();


### PR DESCRIPTION
usleep was removed in POSIX 2008 and is optionally unavailable with
uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

can someone confirm that view1090 has a typo (one extra 0 in the usleep call)?