### PR TITLE
CPR / Position update fix / improvement

### DIFF
--- a/track.c
+++ b/track.c
@@ -898,6 +898,8 @@ static int altitude_to_feet(int raw, altitude_unit_t unit)
 struct aircraft *trackUpdateFromMessage(struct modesMessage *mm)
 {
     struct aircraft *a;
+    unsigned int cpr_new = 0;
+
 
     if (mm->msgtype == 32) {
         // Mode A/C, just count it (we ignore SPI)
@@ -1123,6 +1125,7 @@ struct aircraft *trackUpdateFromMessage(struct modesMessage *mm)
         a->cpr_even_lat = mm->cpr_lat;
         a->cpr_even_lon = mm->cpr_lon;
         compute_nic_rc_from_message(mm, a, &a->cpr_even_nic, &a->cpr_even_rc);
+        cpr_new = 1;
     }
 
     // CPR, odd
@@ -1131,6 +1134,7 @@ struct aircraft *trackUpdateFromMessage(struct modesMessage *mm)
         a->cpr_odd_lat = mm->cpr_lat;
         a->cpr_odd_lon = mm->cpr_lon;
         compute_nic_rc_from_message(mm, a, &a->cpr_odd_nic, &a->cpr_odd_rc);
+        cpr_new = 1;
     }
 
     if (mm->accuracy.sda_valid && accept_data(&a->sda_valid, mm->source)) {
@@ -1182,8 +1186,8 @@ struct aircraft *trackUpdateFromMessage(struct modesMessage *mm)
         combine_validity(&a->altitude_geom_valid, &a->altitude_baro_valid, &a->geom_delta_valid);
     }
 
-    // If we've got a new cprlat or cprlon
-    if (mm->cpr_valid) {
+    // If we've got a new cpr_odd or cpr_even
+    if (cpr_new) {
         updatePosition(a, mm);
     }
 

--- a/track.c
+++ b/track.c
@@ -543,8 +543,12 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm)
             // Nonfatal, try again later.
             Modes.stats_current.cpr_global_skipped++;
         } else {
-            Modes.stats_current.cpr_global_ok++;
-            combine_validity(&a->position_valid, &a->cpr_even_valid, &a->cpr_odd_valid);
+            if (accept_data(&a->position_valid, mm->source)) {
+                Modes.stats_current.cpr_global_ok++;
+            } else {
+                Modes.stats_current.cpr_global_skipped++;
+                location_result = -2;
+            }
         }
     }
 
@@ -552,17 +556,12 @@ static void updatePosition(struct aircraft *a, struct modesMessage *mm)
     if (location_result == -1) {
         location_result = doLocalCPR(a, mm, &new_lat, &new_lon, &new_nic, &new_rc);
 
-        if (location_result < 0) {
-            Modes.stats_current.cpr_local_skipped++;
-        } else {
+        if (location_result == 0 && accept_data(&a->position_valid, mm->source)) {
             Modes.stats_current.cpr_local_ok++;
             mm->cpr_relative = 1;
-
-            if (mm->cpr_odd) {
-                a->position_valid = a->cpr_odd_valid;
-            } else {
-                a->position_valid = a->cpr_even_valid;
-            }
+        } else {
+            Modes.stats_current.cpr_local_skipped++;
+            location_result = -1;
         }
     }
 


### PR DESCRIPTION
This patch should fix an unintended behaviour.
At least that's how i read the intent of the code.

Improves position decoding significantly when two CPR sources for an aircraft are being received at the same time (MLAT and ADS-B for example).

Edit: removed the 2nd patch as it was wrong.
Also like this the PR is limited to a bug fix and not also trying to do something else.