### PR TITLE
Fix invalid JSON after addition of unreliable_tracks

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -1572,7 +1572,7 @@ static char * appendStatsJson(char *p,
                            ",\"altitude_suppressed\":%u"
                            ",\"cpu\":{\"demod\":%llu,\"reader\":%llu,\"background\":%llu}"
                            ",\"tracks\":{\"all\":%u"
-                           ",\"single_message\":%u}"
+                           ",\"single_message\":%u"
                            ",\"unreliable_tracks\":%u}"
                            ",\"messages\":%u}",
                            st->cpr_surface,


### PR DESCRIPTION
When `unreliable_tracks` was added to the JSON output in commit b2e9153653, the trailing `}` after `single_message` should likely have been removed.

Side note: should this just be `unreliable` since it is nested inside `tracks`? `all` and `single_message` don't have the `tracks` suffix.