### PR TITLE
Load lighttpd alias module before using alias.url

### DIFF
--- a/debian/lighttpd/89-dump1090-fa.conf
+++ b/debian/lighttpd/89-dump1090-fa.conf
@@ -3,7 +3,22 @@
 # data and are periodically written by the dump1090 daemon.
 
 # Enable alias module
-server.modules += ( "mod_alias" )
+#
+## This module is normally already enabled in lighttpd, so you should not
+## need to uncommment this line.
+## There are some cases (e.g. when installing this on a Raspberry Pi
+## that runs PiHole) in which the module has been removed from the
+## default configuration, and the dump1090-fa web interface no longer
+## loads properly.
+## If this is what you are experiencing, or if you see messages in your
+## error log like:
+## (server.c.1493) WARNING: unknown config-key: alias.url (ignored)
+## then uncommenting this line and then restarting lighttpd could fix
+## the issue.
+## This is not enabled by default as standard lighttpd will not start if
+## modules are loaded multiple times.
+#
+# server.modules += ( "mod_alias" )
 
 alias.url += (
   "/dump1090-fa/data/" => "/run/dump1090-fa/",

--- a/debian/lighttpd/89-dump1090-fa.conf
+++ b/debian/lighttpd/89-dump1090-fa.conf
@@ -2,6 +2,9 @@
 # and also to the dynamically-generated json parts that contain aircraft
 # data and are periodically written by the dump1090 daemon.
 
+# Enable alias module
+server.modules += ( "mod_alias" )
+
 alias.url += (
   "/dump1090-fa/data/" => "/run/dump1090-fa/",
   "/dump1090-fa/" => "/usr/share/dump1090-fa/html/"


### PR DESCRIPTION
On some instances of lighttpd, like the one that comes with PiHole, the
alias module is not loaded by default. This makes the configuration of
PiAware's lighttpd not work (see e.g.
https://discourse.pi-hole.net/t/pi-hole-and-piaware-lighttpd/9611).

This way we ensure that the alias module is loaded even on non-default
lighttpd configurations.