### PR TITLE
--forward-mlat to affect SBS/port 30003 output as well.

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -555,8 +555,8 @@ static void modesSendSBSOutput(struct modesMessage *mm, struct aircraft *a) {
     if (mm->correctedbits >= 2)
         return;
 
-    // Don't ever forward mlat messages via SBS output.
-    if (mm->source == SOURCE_MLAT)
+    // Don't forward mlat messages, unless --forward-mlat is set
+    if (mm->source == SOURCE_MLAT && !Modes.forward_mlat)
         return;
 
     // Don't ever send unreliable messages via SBS output


### PR DESCRIPTION
(I was hoping to file a bug first to ask why this may be a bad idea, but this seems to be disabled.)

I'm having various things scrape the SBS/port 30003 output to do graphing etc, and only now realised that MLAT data isn't included there. Is there any reason why the `--forward-mlat` flag so far did not include that channel? If not, is this a sensible PR?

I'm running this version here now and it produces the expected output, now including the various GA planes flying around here.