### PR TITLE
Add commented-out HTTPS configuration section

### DIFF
--- a/debian/lighttpd/89-dump1090-fa.conf
+++ b/debian/lighttpd/89-dump1090-fa.conf
@@ -29,6 +29,7 @@ $HTTP["url"] =~ "^/dump1090-fa/data/.*\.json$" {
 # Uncomment this section to enable SSL traffic (HTTPS) - especially useful
 # for .dev domains
 ## Listen on 8443 for SSL connections
+#server.modules += ( "mod_openssl" )
 #$HTTP["host"] == "piaware.example.com" {
 #  $SERVER["socket"] == ":8443" {
 #    ssl.engine = "enable"
@@ -44,12 +45,12 @@ $HTTP["url"] =~ "^/dump1090-fa/data/.*\.json$" {
 #    "/" => "/usr/share/dump1090-fa/html/"
 #  )
 #  }
+#}
 #
-#  # Redirect HTTP to HTTPS
-#  $HTTP["scheme"] == "http" {
-#    $HTTP["host"] =~ ".*" {
-#      url.redirect = (".*" => "https://%0$0")
-#    }
+## Redirect HTTP to HTTPS
+#$HTTP["scheme"] == "http" {
+#  $HTTP["host"] =~ ".*" {
+#    url.redirect = (".*" => "https://%0$0")
 #  }
 #}
 

--- a/debian/lighttpd/89-dump1090-fa.conf
+++ b/debian/lighttpd/89-dump1090-fa.conf
@@ -25,3 +25,31 @@ server.modules += ( "mod_setenv" )
 $HTTP["url"] =~ "^/dump1090-fa/data/.*\.json$" {
   setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
 }
+
+# Uncomment this section to enable SSL traffic (HTTPS) - especially useful
+# for .dev domains
+## Listen on 8443 for SSL connections
+#$HTTP["host"] == "piaware.example.com" {
+#  $SERVER["socket"] == ":8443" {
+#    ssl.engine = "enable"
+#    ssl.pemfile = "/root/ssl_certificate/combined.pem"
+#    ssl.ca-file =  "/root/ssl_certificate/fullchain.cer"
+#    ssl.honor-cipher-order = "enable"
+#    ssl.cipher-list = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"
+#    ssl.use-sslv2 = "disable"
+#    ssl.use-sslv3 = "disable"       
+#    
+#  alias.url += (
+#    "/data/" => "/run/dump1090-fa/",
+#    "/" => "/usr/share/dump1090-fa/html/"
+#  )
+#  }
+#
+#  # Redirect HTTP to HTTPS
+#  $HTTP["scheme"] == "http" {
+#    $HTTP["host"] =~ ".*" {
+#      url.redirect = (".*" => "https://%0$0")
+#    }
+#  }
+#}
+

--- a/debian/lighttpd/89-dump1090-fa.conf
+++ b/debian/lighttpd/89-dump1090-fa.conf
@@ -33,8 +33,8 @@ $HTTP["url"] =~ "^/dump1090-fa/data/.*\.json$" {
 #$HTTP["host"] == "piaware.example.com" {
 #  $SERVER["socket"] == ":8443" {
 #    ssl.engine = "enable"
-#    ssl.pemfile = "/root/ssl_certificate/combined.pem"
-#    ssl.ca-file =  "/root/ssl_certificate/fullchain.cer"
+#    ssl.pemfile = "/etc/ssl/certs/combined.pem"
+#    ssl.ca-file =  "/etc/ssl/certs/fullchain.cer"
 #    ssl.honor-cipher-order = "enable"
 #    ssl.cipher-list = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"
 #    ssl.use-sslv2 = "disable"


### PR DESCRIPTION
In recent versions of Firefox and (especially) Chrome, ".dev" domains are
force-redirected to a secure connection (HTTPS) instead of HTTP. Not
supporting an HTTPS connection makes for a bad user experience, so we want
to make enabling SSL support easy. Since we don't issue certificates, this
section is commented out by default, and it will require modification.

This is done primarily for PiAware, though it is applicable to just the
Dump1090 project.

This functionality has been tested with a LetsEncrypt certificate on PiAware 3.8.1.