### PR TITLE
Use set-response-header instead of add-response-header

### DIFF
--- a/debian/lighttpd/89-dump1090-fa.conf
+++ b/debian/lighttpd/89-dump1090-fa.conf
@@ -23,5 +23,5 @@ $SERVER["socket"] == ":8080" {
 # Add CORS header
 server.modules += ( "mod_setenv" )
 $HTTP["url"] =~ "^/dump1090-fa/data/.*\.json$" {
-  setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
+  setenv.set-response-header = ( "Access-Control-Allow-Origin" => "*" )
 }


### PR DESCRIPTION
When accessing Dump 1090 JSON from another web server, I found that the "Access-Control-Allow-Origin" parameter was set twice ("*, *") which Chrome objected to. By changing "add-response-header" to "set-response-header" we ensure that the correct header is sent, but never duplicated.