### PR TITLE
Block Piaware Skyaware search indexing

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -2,6 +2,7 @@
 <html>
 	<head>
 		<meta charset="utf-8"/>
+		<meta name="robots" content="noindex">
 		<link rel="stylesheet" type="text/css" href="style.css?v=3.8.1" />
 		<link rel="stylesheet" href="jquery/jquery-ui-1.11.4-smoothness.css" />
 		<script src="jquery/jquery-3.0.0.min.js"></script>


### PR DESCRIPTION
Google seems to be indexing Piaware Skyaware pages, doing a Google search for "Piaware Skyaware" shows lots of instances that are exposed directly to the internet also exposing the users public IP and in many occasions the user's location through the receiver.json file. Adding the 'noindex' meta tag disables most web crawlers.

For reference: https://support.google.com/webmasters/answer/93710?hl=en