### PR TITLE
fix(web): add empty coordinates to constructor

### DIFF
--- a/public_html/script.js
+++ b/public_html/script.js
@@ -944,7 +944,7 @@ function initialize_map() {
                 });
 
                 for (var i = 0; i < data.rings.length; ++i) {
-                        var geom = new ol.geom.LineString();
+                        var geom = new ol.geom.LineString([]);
                         var points = data.rings[i].points;
                         if (points.length > 0) {
                                 for (var j = 0; j < points.length; ++j) {


### PR DESCRIPTION
Change LineString constructor creation, see deprecated null constructor https://github.com/openlayers/openlayers/blob/main/changelog/upgrade-notes.md#v510

![image](https://user-images.githubusercontent.com/6797195/94807760-61a26880-03f0-11eb-9760-b85a4d96c15c.png)
