### PR TITLE
convert: Add two new converters

### DIFF
--- a/convert.h
+++ b/convert.h
@@ -21,7 +21,7 @@
 #define DUMP1090_CONVERT_H
 
 struct converter_state;
-typedef enum { INPUT_UC8=0, INPUT_SC16, INPUT_SC16Q11 } input_format_t;
+typedef enum { INPUT_NONE = -1, INPUT_UC8, INPUT_SC16, INPUT_SC16Q11, INPUT_INT16, INPUT_UINT16_OFFSET12 } input_format_t;
 
 typedef void (*iq_convert_fn)(void *iq_data,
                               uint16_t *mag_data,
@@ -36,5 +36,7 @@ iq_convert_fn init_converter(input_format_t format,
                              struct converter_state **out_state);
 
 void cleanup_converter(struct converter_state *state);
+const char *formatGetName(input_format_t format_type);
+input_format_t formatGetByName(const char *name);
 
 #endif

--- a/util.h
+++ b/util.h
@@ -22,6 +22,12 @@
 
 #include <stdint.h>
 
+/* Absolute value */
+#define ABS(__i) (__i < 0 ? -__i : __i)
+
+/* Get the size of an array */
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
 /* Returns system time in milliseconds */
 uint64_t mstime(void);
 


### PR DESCRIPTION
 * Added s16 converter which converts full scale signed
   16 bit integers to full scale unsigned integers.
   Intermediate downscaling to 12 bit is performed to
   allow the use of reasonable sized LUTs for power
   and magnitude.

* Added u16o12 converter which converts 12 bit samples
  that have been offset by 12 bits to full scale
  unsigned integers.  The same LUTs as above are used
  for power and magnitude.

* Added functions to get the name of a converter from
  it's format value and to get a converter by its name
  in preparation for being able to specify
  --sample-format on the command line.