### PR TITLE
fixed screen (first line) issue when in the interactive mode

### DIFF
--- a/interactive.c
+++ b/interactive.c
@@ -103,7 +103,7 @@ void interactiveNoConnection(void) {
 void interactiveShowData(void) {
     struct aircraft *a = Modes.aircrafts;
     static uint64_t next_update;
-    static _Bool need_clear = true;
+    static bool need_clear = true;
     uint64_t now = mstime();
     char progress;
     char spinner[4] = "|/-\\";

--- a/interactive.c
+++ b/interactive.c
@@ -103,6 +103,7 @@ void interactiveNoConnection(void) {
 void interactiveShowData(void) {
     struct aircraft *a = Modes.aircrafts;
     static uint64_t next_update;
+    static _Bool need_clear = true;
     uint64_t now = mstime();
     char progress;
     char spinner[4] = "|/-\\";
@@ -110,6 +111,10 @@ void interactiveShowData(void) {
     if (!Modes.interactive)
         return;
 
+    if (need_clear) {
+        clear();
+        need_clear = false;
+    }
     // Refresh screen every (MODES_INTERACTIVE_REFRESH_TIME) miliseconde
     if (now < next_update)
         return;


### PR DESCRIPTION
Running dump1090 on `Linux tvv 5.4.0-66-generic #74-Ubuntu SMP Wed Jan 27 22:54:38 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux` with `rtl-sdr` and `ncurses 6.2-0ubuntu2` I found an oddity with diplaying a topline.
Another library/process output spoils formatted print of interactive.c [-> see spoiled view example here](https://ibb.co/z64bzbc).
I added a flag and clear() call to be sure that the screen is cleared before interactive.c starts print [-> see correct behavour here](https://ibb.co/7yRBWmX).

