### PR TITLE
Add link to the receiver's FlightAware stats page

### DIFF
--- a/public_html/config.js
+++ b/public_html/config.js
@@ -35,6 +35,10 @@ SiteShow    = false;           // true to show a center marker
 SiteLat     = 45.0;            // position of the marker
 SiteLon     = 9.0;
 SiteName    = "My Radar Site"; // tooltip of the marker
+// FlightAware stats page for this receiver.
+// Defaults to https://flightaware.com/adsb/stats/user/ which
+// redirects to the user's stats page if the user is logged in.
+SiteStats   = "";
 
 // -- Marker settings -------------------------------------
 

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -197,6 +197,9 @@
 												<div class="button buttonTable" id="show_map_button"><span class="buttonText">Show Map</span></div>
 											</td>
 											<td style="text-align: right">
+												<a href="https://flightaware.com/adsb/stats/user/" id="flightaware_radar_stats" target="_blank">Your receiver's FlightAware stats</a>
+											</td>
+											<td style="text-align: right">
 												<a href="https://github.com/flightaware/dump1090" id="dump1090_version" target="_blank"></a>
 											</td>
 										</tr>

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -214,6 +214,9 @@ var PositionHistorySize = 0;
 function initialize() {
         // Set page basics
         document.title = PageName;
+        if (SiteStats) {
+                $('#flightaware_radar_stats').attr("href", SiteStats);
+        }
 
         flightFeederCheck();
 


### PR DESCRIPTION
Allows the user to easily access his receiver's statistics page on the FlightAware website:

![Capture d’écran de 2021-03-07 16-33-41](https://user-images.githubusercontent.com/229379/110245365-035f5000-7f63-11eb-9f06-d05762480583.png)

By default, the link is [https://flightaware.com/adsb/stats/user/](https://flightaware.com/adsb/stats/user/) which redirects to the user's stats page if the user is logged in.
This PR also makes it possible to specify the correct direct link (in my case [https://flightaware.com/adsb/stats/user/e2jk](https://flightaware.com/adsb/stats/user/e2jk) in the `public_html/config.js` file.