### PR TITLE
restrict overlay rendering to covered areas (reduce source load)

### DIFF
--- a/public_html_merged/layers.js
+++ b/public_html_merged/layers.js
@@ -149,12 +149,16 @@ function createBaseLayers() {
                 }
         }
 
+        var nexrad_bottomLeft = ol.proj.fromLonLat([-171.0,9.0]);
+        var nexrad_topRight = ol.proj.fromLonLat([-51.0,69.0]);
+        var nexrad_extent = [nexrad_bottomLeft[0], nexrad_bottomLeft[1], nexrad_topRight[0], nexrad_topRight[1]];
         var nexrad = new ol.layer.Tile({
                 name: 'nexrad',
                 title: 'NEXRAD',
                 type: 'overlay',
                 opacity: 0.5,
-                visible: false
+                visible: false,
+                extent: nexrad_extent,
         });
         us.push(nexrad);
 
@@ -210,6 +214,9 @@ function createBaseLayers() {
                 });
             };
 
+        var dwd_bottomLeft = ol.proj.fromLonLat([1.9,46.2]);
+        var dwd_topRight = ol.proj.fromLonLat([16.0,55.0]);
+        var dwd_extent = [dwd_bottomLeft[0], dwd_bottomLeft[1], dwd_topRight[0], dwd_topRight[1]];
         var dwd = new ol.layer.Tile({
                 source: new ol.source.TileWMS({
                         url: 'https://maps.dwd.de/geoserver/wms',
@@ -224,6 +231,7 @@ function createBaseLayers() {
                 visible: false,
                 zIndex: 99,
                 maxZoom: 14,
+                exent: dwd_extent,
         });
 
         var refreshDwd = function () {


### PR DESCRIPTION
This also applies to the FA anywhere map.