### PR TITLE
Stratux output: include current receiver gain

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -839,12 +839,14 @@ static void modesSendStratuxOutput(struct modesMessage *mm, struct aircraft *a) 
             "\"TypeCode\":%d,"
             "\"SubtypeCode\":%d,"
             "\"SignalLevel\":%f,"
+            "\"Gain\":%f,"
             "\"IsMlat\":%s,",
             mm->addr,
             mm->msgtype, cacf,
             mm->metype,
             mm->mesub,
             mm->signalLevel, // what precision and range is needed for RSSI?
+            sdrGetGainDb(sdrGetGain()),
             is_mlat_str);
 
     //// callsign


### PR DESCRIPTION
Hi,
With the next Stratux release, we would like to move to the new adaptive gain control stuff, since we absolutely do care about nearby traffic not getting lost. We'll do flight tests soon to see how well the adaptive gain deals with the fact that there is a transponder **very** close - as in only like a meter away.
However, since we also try to estimate the distance of Mode-S only targets based on signal strength, we do also need to factor in the variable gain in the future.

This PR adds the current Gain value to the Stratux output, so we can include it in the Mode-S distance calculation. Hope that's the correct way to get the gain value and that there are no corner cases where that doesn't work. Not too familiar with the dump1090 code base.

EDIT: would be happy if you could give some insight what you think about enabling this adaptive gain in an on-board situation - or if there is a good reason to **not** do it.

EDIT2: FYI, I did a flight test today with --adaptive-burst --adaptive-range.
During the ~45 minutes of flight, there were 29 gain changes. Amount of packets received on each distinct gain level. My own transponder was received most of the time. When gain went down to <40, there were no other targets with strong signals. Just my transponder. If you are interested in more detailed data, let me know.

Gain|Pkts
37.2|5121
38.6|2255
40.2|1284
42.1|2252
43.4|2228
43.9|2897
44.5|6300
48.0|4296
49.6|142344
58.6|508