### PR TITLE
Disabled compiler warnings on external code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,8 +175,7 @@ else
 endif
 all: showconfig dump1090 view1090 starch-benchmark
 
-# Compile starch generated code without warnings and -Werror
-STARCH_COMPILE := $(CC) $(CPPFLAGS) $(CFLAGS) -c
+STARCH_COMPILE := $(CC) $(CPPFLAGS) $(CFLAGS) $(WARNINGFLAGS) -c
 include dsp/generated/makefile.$(STARCH_MIX)
 
 showconfig:


### PR DESCRIPTION
Disabled compiler warnings on external code so that the starch generated code and cpu_features don't break the compilation process on different compilers.