### PR TITLE
Makefile: set _POSIX_C_SOURCE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DUMP1090_VERSION ?= unknown
 
 CFLAGS ?= -O3 -g
 DUMP1090_CFLAGS := -std=c11 -fno-common -Wall -Wmissing-declarations -Werror -W
-DUMP1090_CPPFLAGS := -I. -DMODES_DUMP1090_VERSION=\"$(DUMP1090_VERSION)\" -DMODES_DUMP1090_VARIANT=\"dump1090-fa\"
+DUMP1090_CPPFLAGS := -I. -D_POSIX_C_SOURCE=200112L -DMODES_DUMP1090_VERSION=\"$(DUMP1090_VERSION)\" -DMODES_DUMP1090_VARIANT=\"dump1090-fa\"
 
 LIBS = -lpthread -lm
 SDR_OBJ = cpu.o sdr.o fifo.o sdr_ifile.o dsp/helpers/tables.o


### PR DESCRIPTION
Set `-D_POSIX_C_SOURCE=200112L` to avoid the following build failure with uclibc-ng:

```
anet.c: In function ‘anetTcpGenericConnect’:
anet.c:153:21: error: storage size of ‘gai_hints’ isn’t known
  153 |     struct addrinfo gai_hints;
      |                     ^~~~~~~~~

In file included from dump1090.h:83,
                 from dump1090.c:50:
compat/compat.h:46:3: error: conflicting types for ‘clockid_t’
   46 | } clockid_t;
      |   ^~~~~~~~~
In file included from /home/fabrice/buildroot/output/host/or1k-buildroot-linux-uclibc/sysroot/usr/include/sys/types.h:132,
                 from /home/fabrice/buildroot/output/host/or1k-buildroot-linux-uclibc/sysroot/usr/include/stdlib.h:198,
                 from dump1090.h:66,
                 from dump1090.c:50:
/home/fabrice/buildroot/output/host/or1k-buildroot-linux-uclibc/sysroot/usr/include/time.h:91:21: note: previous declaration of ‘clockid_t’ was here
   91 | typedef __clockid_t clockid_t;
      |                     ^~~~~~~~~

net_io.c: In function ‘writeJsonToFile’:
net_io.c:2122:18: error: ‘PATH_MAX’ undeclared (first use in this function)
 2122 |     char pathbuf[PATH_MAX];
      |                  ^~~~~~~~
```
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>