### PR TITLE
Fix syntax error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ ifeq ($(UNAME), Darwin)
   LIBS_USB += -lusb-1.0
   LIBS_CURSES := -lncurses
   # cpufeatures reportedly does not work (yet) on darwin arm64
-  ifneq $($(ARCH),arm64)
+  ifneq ($(ARCH),arm64)
     CPUFEATURES ?= yes
   endif
 endif


### PR DESCRIPTION
Fixes `Makefile:66: *** invalid syntax in conditional.  Stop.` error