### PR TITLE
Fix build issue in mac os

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -54,6 +54,7 @@
 
 #include <assert.h>
 #include <stdarg.h>
+#include <alloca.h>
 
 //
 // ============================= Networking =============================

--- a/sdr.c
+++ b/sdr.c
@@ -34,6 +34,8 @@
 #  include "sdr_limesdr.h"
 #endif
 
+#include <strings.h>
+
 typedef struct {
     const char *name;
     sdr_type_t sdr_type;

--- a/sdr_ifile.c
+++ b/sdr_ifile.c
@@ -51,6 +51,8 @@
 #include "dump1090.h"
 #include "sdr_ifile.h"
 
+#include <strings.h>
+
 static struct {
     const char *filename;
     input_format_t input_format;


### PR DESCRIPTION
Build fails on MacOS Monterey 12.3.1 because of missing includes.

```
% cc -v
Apple clang version 13.1.6 (clang-1316.0.21.2.3)
Target: arm64-apple-darwin21.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```



This PR fixes build issue.