### PR TITLE
Fix dropped samples counting

### DIFF
--- a/fifo.c
+++ b/fifo.c
@@ -159,6 +159,9 @@ struct mag_buf *fifo_acquire(uint32_t timeout_ms)
         result->sampleTimestamp = 0;
         result->sysTimestamp = 0;
         result->flags = 0;
+        result->mean_level = 0;
+        result->mean_power = 0;
+        result->dropped = 0;
         result->next = NULL;
     }
 

--- a/fifo.h
+++ b/fifo.h
@@ -64,7 +64,7 @@ struct mag_buf {
     mag_buf_flags   flags;           // bitwise flags for this buffer
     double          mean_level;      // Mean of normalized (0..1) signal level
     double          mean_power;      // Mean of normalized (0..1) power level
-    unsigned        dropped;         // (approx) number of dropped samples, if flag MAGBUF_DISCONTINUOUS is set
+    unsigned        dropped;         // (approx) number of dropped samples, if flag MAGBUF_DISCONTINUOUS is set; zero if not discontinuous
 
     struct mag_buf *next;            // linked list forward link
 };


### PR DESCRIPTION
Zero out `dropped` on FIFO buffers for contiguous buffers; document that dropped == 0 for contiguous buffers.

Fixes #178 