### PR TITLE
Flag to encode system timestamp in Beast output

### DIFF
--- a/dump1090.h
+++ b/dump1090.h
@@ -331,11 +331,13 @@ struct _Modes {                             // Internal state
 
     struct net_service *beast_verbatim_service;        // Beast-format output service, verbatim mode
     struct net_service *beast_verbatim_local_service;  // Beast-format output service, verbatim+local mode
+    struct net_service *beast_sys_time_service;        // Beast-format output service, "cooked" mode, system timestamp
     struct net_service *beast_cooked_service;          // Beast-format output service, "cooked" mode
 
     struct net_writer raw_out;                   // AVR-format output
     struct net_writer beast_verbatim_out;        // Beast-format output, verbatim mode
     struct net_writer beast_verbatim_local_out;  // Beast-format output, verbatim+local mode
+    struct net_writer beast_sys_time_out;        // Beast-format output, "cooked" mode, system timestamp
     struct net_writer beast_cooked_out;          // Beast-format output, "cooked" mode
     struct net_writer sbs_out;                   // SBS-format output
     struct net_writer stratux_out;               // Stratux-format output

--- a/net_io.h
+++ b/net_io.h
@@ -62,6 +62,8 @@ struct client {
     int    modeac_requested;             // 1 if this Beast output connection has asked for A/C
     int    verbatim_requested;           // 1 if this Beast output connection has asked for verbatim mode
     int    local_requested;              // 1 if this Beast output connection has asked for local-only mode
+    int    sys_time_requested;           // 1 if this Beast output connection has asked for message timestamps
+                                         //   to be from the system clock in milliseconds since epoch
 };
 
 // Common writer state for all output sockets of one type


### PR DESCRIPTION
The `--beast-sys-time` flag allows a user to specify that Beast output messages should include the system timestamp (in milliseconds since the epoch) instead of an input device-specific timestamp. Providing this flag does not change the timestamp printed with each decoded message such as the example in issue #163.