### PR TITLE
Makefile: use pkg-config to detect libusb on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,9 @@ ifeq ($(UNAME), Darwin)
   endif
   DUMP1090_CPPFLAGS += -DMISSING_NANOSLEEP
   COMPAT += compat/clock_nanosleep/clock_nanosleep.o
+  ifeq ($(PKGCONFIG), yes)
+    LIBS_SDR += $(shell pkg-config --libs-only-L libusb-1.0)
+  endif
   LIBS_USB += -lusb-1.0
   LIBS_CURSES := -lncurses
   # cpufeatures reportedly does not work (yet) on darwin arm64


### PR DESCRIPTION
Makefile: use pkg-config to detect libusb on macOS
Some versions of librtlsdr (including the version installed by Homebrew
bottle) wrongly declare -lusb-1.0 in its pkg-config file's Libs section.
On Apple Silicon Macs, Homebrew installs libusb dylibs in /opt/homebrew/lib,
which is not a known path for linkers and causes build failure. Some people
reported this linker problem in https://github.com/flightaware/dump1090/issues/166, https://github.com/flightaware/dump1090/issues/181. This should fix it.

For the redundant -lusb-1.0 problem, also see:
https://gitea.osmocom.org/sdr/rtl-sdr/commit/222517b506278178ab93182d79ccf7eb04d107ce