### PR TITLE
Add remote configurable output port

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -396,6 +396,7 @@ static void showHelp(void)
 "--net-bi-port <ports>    TCP Beast input listen ports  (default: 30004,30104)\n"
 "--net-bo-port <ports>    TCP Beast output listen ports (default: 30005)\n"
 "--net-stratux-port <ports>  TCP Stratux output listen ports (default: disabled)\n"
+"--net-dynamic-port <ports>  TCP remote configurable output ports  (default: 30006)\n"
 "--net-ro-size <size>     TCP output minimum size (default: 0)\n"
 "--net-ro-interval <rate> TCP output memory flush rate in seconds (default: 0)\n"
 "--net-heartbeat <rate>   TCP heartbeat rate in seconds\n"
@@ -589,6 +590,8 @@ static void applyNetDefaults()
         Modes.net_input_beast_ports = strdup("30004,30104");
     if (!Modes.net_output_beast_ports)
         Modes.net_output_beast_ports = strdup("30005");
+    if (!Modes.net_output_dynamic_ports)
+        Modes.net_output_dynamic_ports = strdup("30006");
 }
 
 int main(int argc, char **argv) {
@@ -689,7 +692,11 @@ int main(int argc, char **argv) {
             Modes.net = 1;
             free(Modes.net_output_stratux_ports);
             Modes.net_output_stratux_ports = strdup(argv[++j]);
-        } else if (!strcmp(argv[j],"--net-buffer") && more) {
+        } else if (!strcmp(argv[j],"--net-dynamic-port") && more) {
+            Modes.net = 1;
+            free(Modes.net_output_dynamic_ports);
+            Modes.net_output_dynamic_ports = strdup(argv[++j]);
+        }  else if (!strcmp(argv[j],"--net-buffer") && more) {
             Modes.net_sndbuf_size = atoi(argv[++j]);
         } else if (!strcmp(argv[j],"--net-verbatim")) {
             Modes.net_verbatim = 1;

--- a/dump1090.h
+++ b/dump1090.h
@@ -326,17 +326,8 @@ struct _Modes {                             // Internal state
     // Networking
     char           aneterr[ANET_ERR_LEN];
     struct net_service *services;    // Active services
+    struct net_writer *writers[OUT_SERVICE_FORMAT_COUNT];
     struct client *clients;          // Our clients
-
-    struct net_service *beast_verbatim_service;  // Beast-format output service, verbatim mode
-    struct net_service *beast_cooked_service;    // Beast-format output service, "cooked" mode
-
-    struct net_writer raw_out;                   // AVR-format output
-    struct net_writer beast_verbatim_out;        // Beast-format output, verbatim mode
-    struct net_writer beast_cooked_out;          // Beast-format output, "cooked" mode
-    struct net_writer sbs_out;                   // SBS-format output
-    struct net_writer stratux_out;               // Stratux-format output
-    struct net_writer fatsv_out;                 // FATSV-format output
 
 #ifdef _WIN32
     WSADATA        wsaData;          // Windows socket initialisation
@@ -362,6 +353,7 @@ struct _Modes {                             // Internal state
     char *net_output_stratux_ports;  // List of Stratux output TCP ports
     char *net_input_beast_ports;     // List of Beast input TCP ports
     char *net_output_beast_ports;    // List of Beast output TCP ports
+    char *net_output_dynamic_ports;  // List of Remote configurable output TCP ports
     char *net_bind_address;          // Bind address
     int   net_sndbuf_size;           // TCP output buffer size (64Kb * 2^n)
     int   net_verbatim;              // if true, Beast output connections default to verbatim mode


### PR DESCRIPTION
Hey! Not so small pull request here.

The idea is to add one more output mode but in a way that does no increase complexity.

So I added this dynamic port (default 30006), that when you connect gives you a hello JSON with the variant and version of dump1090, and then you send a string to select the stream you want, for example "s\n" for SBS.

The previous switchable mechanism of COOKED vs VERBATIM didn't allow to know safely which stream we were actually getting because there was no ACK and the default depended on dump1090 general config, which we might not control.

And this is to get a reliable way to obtain a verbatim stream, but also without any eventual remote results. We called it BEAST_ANTENNA.

I'm sure this can be improved and I wait for your comments.
