### PR TITLE
Emit current SDR gain in the local receiver stats

### DIFF
--- a/README-json.md
+++ b/README-json.md
@@ -122,23 +122,24 @@ Each period has the following subkeys:
  * start: the start time (in seconds-since-1-Jan-1970) of this statistics collection period.
  * end: the end time (in seconds-since-1-Jan-1970) of this statistics collection period.
  * local: statistics about messages received from a local SDR dongle. Not present in --net-only mode. Has subkeys:
-   * blocks_processed: number of sample blocks processed
-   * blocks_dropped: number of sample blocks dropped before processing. A nonzero value means CPU overload.
+   * samples_processed: number of samples processed
+   * samples_dropped: number of samples dropped before processing. A nonzero value means CPU overload.
    * modeac: number of Mode A / C messages decoded
    * modes: number of Mode S preambles received. This is *not* the number of valid messages!
    * bad: number of Mode S preambles that didn't result in a valid message
    * unknown_icao: number of Mode S preambles which looked like they might be valid but we didn't recognize the ICAO address and it was one of the message types where we can't be sure it's valid in this case.
    * accepted: array. Index N has the number of valid Mode S messages accepted with N-bit errors corrected.
    * signal: mean signal power of successfully received messages, in dbFS; always negative.
+   * noise: mean noise power of non-message samples, in dbFS; always negative.
    * peak_signal: peak signal power of a successfully received message, in dbFS; always negative.
    * strong_signals: number of messages received that had a signal power above -3dBFS.
+   * gain_db: the current SDR gain, floating-point dB. Might be absent depending on SDR type.
  * remote: statistics about messages received from remote clients. Only present in --net or --net-only mode. Has subkeys:
    * modeac: number of Mode A / C messages received.
    * modes: number of Mode S messages received.
    * bad: number of Mode S messages that had bad CRC or were otherwise invalid.
    * unknown_icao: number of Mode S messages which looked like they might be valid but we didn't recognize the ICAO address and it was one of the message types where we can't be sure it's valid in this case.
    * accepted: array. Index N has the number of valid Mode S messages accepted with N-bit errors corrected.
-   * http_requests: number of HTTP requests handled.
  * cpu: statistics about CPU use. Has subkeys:
    * demod: milliseconds spent doing demodulation and decoding in response to data from a SDR dongle
    * reader: milliseconds spent reading sample data over USB from a SDR dongle
@@ -163,5 +164,14 @@ Each period has the following subkeys:
    as a new track.
    * all: total tracks created
    * single_message: tracks consisting of only a single message. These are usually due to message decoding errors that produce a bad aircraft address.
+   * unreliable: tracks that were never marked as reliable. These are also usually due to message decoding errors.
  * messages: total number of messages accepted by dump1090 from any source
  * messages_by_df: an array of integers where entry N (0..31) is the total number of messages accepted with downlink format (DF) = N.
+ * adaptive: statistics on adaptive gain. Only present if adaptive gain is enabled
+   * gain_db: latest SDR gain (legacy; prefer to use `local.gain_db` instead)
+   * dynamic_range_limit_db: latest dynamic-range-controlled upper gain limit, dB
+   * gain_changes: number of gain changes made in this stats period
+   * loud_undecoded: number of undecodable loud probably-a-valid-message bursts seen
+   * loud_decoded: number of correctly decoded mesaages with a high signal level
+   * noise_dbfs: adaptive gain noise floor estimate, dBFS
+   * gain_seconds: object, keyed by integer gain step, values are an array of [floating point gain in dB, number of seconds spent at this gain setting]

--- a/adaptive.c
+++ b/adaptive.c
@@ -468,9 +468,11 @@ static void adaptive_end_of_block()
     adaptive_control_update();
 
     Modes.stats_current.adaptive_valid = true;
-    unsigned current = Modes.stats_current.adaptive_gain = sdrGetGain();
     Modes.stats_current.adaptive_range_gain_limit = adaptive_range_gain_limit;
-    ++Modes.stats_current.adaptive_gain_seconds[current < STATS_GAIN_COUNT ? current : STATS_GAIN_COUNT-1];
+
+    unsigned current = sdrGetGain();
+    if (current >= 0)
+        ++Modes.stats_current.adaptive_gain_seconds[current < STATS_GAIN_COUNT ? current : STATS_GAIN_COUNT-1];
 }
 
 static void adaptive_control_update()

--- a/dump1090.c
+++ b/dump1090.c
@@ -441,6 +441,10 @@ static void showHelp(void)
 void flush_stats(uint64_t now);
 void flush_stats(uint64_t now)
 {
+    if (Modes.sdr_type != SDR_NONE) {
+        Modes.stats_current.sdr_gain = sdrGetGain();
+    }
+
     add_stats(&Modes.stats_current, &Modes.stats_periodic, &Modes.stats_periodic);
     add_stats(&Modes.stats_current, &Modes.stats_alltime, &Modes.stats_alltime);
     add_stats(&Modes.stats_current, &Modes.stats_latest, &Modes.stats_latest);
@@ -840,6 +844,13 @@ int main(int argc, char **argv) {
     }
 
     // init stats:
+    reset_stats(&Modes.stats_current);
+    reset_stats(&Modes.stats_alltime);
+    reset_stats(&Modes.stats_periodic);
+    reset_stats(&Modes.stats_latest);
+    reset_stats(&Modes.stats_5min);
+    reset_stats(&Modes.stats_15min);
+
     Modes.stats_current.start = Modes.stats_current.end =
         Modes.stats_alltime.start = Modes.stats_alltime.end =
         Modes.stats_periodic.start = Modes.stats_periodic.end =
@@ -847,8 +858,10 @@ int main(int argc, char **argv) {
         Modes.stats_5min.start = Modes.stats_5min.end =
         Modes.stats_15min.start = Modes.stats_15min.end = mstime();
 
-    for (j = 0; j < 15; ++j)
+    for (j = 0; j < 15; ++j) {
+        reset_stats(&Modes.stats_1min[j]);
         Modes.stats_1min[j].start = Modes.stats_1min[j].end = Modes.stats_current.start;
+    }
 
     adaptive_init();
 

--- a/net_io.c
+++ b/net_io.c
@@ -1884,7 +1884,10 @@ static char * appendStatsJson(char *p,
         if (st->peak_signal_power > 0)
             p = safe_snprintf(p, end, ",\"peak_signal\":%.1f", 10 * log10(st->peak_signal_power));
 
-        p = safe_snprintf(p, end, ",\"strong_signals\":%d}", st->strong_signal_count);
+        p = safe_snprintf(p, end, ",\"strong_signals\":%d", st->strong_signal_count);
+        if (st->sdr_gain >= 0)
+            p = safe_snprintf(p, end, ",\"gain_db\":%.1f", sdrGetGainDb(st->sdr_gain));
+        p = safe_snprintf(p, end, "}");
     }
 
     if (Modes.net) {
@@ -1972,7 +1975,7 @@ static char * appendStatsJson(char *p,
                           ",\"loud_decoded\":%u"
                           ",\"noise_dbfs\":%.1f"
                           ",\"gain_seconds\":[",
-                          sdrGetGainDb(st->adaptive_gain),
+                          sdrGetGainDb(st->sdr_gain),
                           sdrGetGainDb(st->adaptive_range_gain_limit),
                           st->adaptive_gain_changes,
                           st->adaptive_loud_undecoded,

--- a/stats.h
+++ b/stats.h
@@ -67,6 +67,9 @@ struct stats {
     uint64_t samples_processed;
     uint64_t samples_dropped;
 
+    // SDR settings:
+    int sdr_gain;  // current gain step in use
+
     // timing:
     struct timespec demod_cpu;
     struct timespec reader_cpu;
@@ -133,7 +136,6 @@ struct stats {
     // adaptive gain measurements
 #define STATS_GAIN_COUNT 64
     bool adaptive_valid;                                // is the following data valid?
-    int adaptive_gain;                                  // Current gain step in use
     uint32_t adaptive_gain_seconds[STATS_GAIN_COUNT];   // Seconds spent at each gain step
     uint32_t adaptive_loud_undecoded;                   // Total number of loud, undecoded bursts
     uint32_t adaptive_loud_decoded;                     // Total number of loud, decoded messages


### PR DESCRIPTION
Always emit this, even if adaptive gain is disabled.

For backwards compatibility the gain is still emitted in the old stats location as well if adaptive gain is enabled.

sample output:

```
{
  "latest": {
    "start": 1665032717.8,
    "end": 1665032777,
    "local": {      
      "samples_processed": 142213120,
      "samples_dropped": 0,
      "modeac": 0,
      "modes": 875641,
      "bad": 3471481,
      "unknown_icao": 369459,
      "accepted": [
        0
      ],
      "noise": -11.1,
      "strong_signals": 0,
      "gain_db": 49.6              <-------
    },
...
```
