### PR TITLE
Support a new 'l'/'L' Beast option; when enabled, send only locally-generated messages

### DIFF
--- a/dump1090.h
+++ b/dump1090.h
@@ -329,11 +329,13 @@ struct _Modes {                             // Internal state
     struct net_service *services;    // Active services
     struct client *clients;          // Our clients
 
-    struct net_service *beast_verbatim_service;  // Beast-format output service, verbatim mode
-    struct net_service *beast_cooked_service;    // Beast-format output service, "cooked" mode
+    struct net_service *beast_verbatim_service;        // Beast-format output service, verbatim mode
+    struct net_service *beast_verbatim_local_service;  // Beast-format output service, verbatim+local mode
+    struct net_service *beast_cooked_service;          // Beast-format output service, "cooked" mode
 
     struct net_writer raw_out;                   // AVR-format output
     struct net_writer beast_verbatim_out;        // Beast-format output, verbatim mode
+    struct net_writer beast_verbatim_local_out;  // Beast-format output, verbatim+local mode
     struct net_writer beast_cooked_out;          // Beast-format output, "cooked" mode
     struct net_writer sbs_out;                   // SBS-format output
     struct net_writer stratux_out;               // Stratux-format output

--- a/net_io.c
+++ b/net_io.c
@@ -417,7 +417,7 @@ static void modesSendBeastVerbatimLocalOutput(struct modesMessage *mm) {
         return;
 
     // Do verbatim output for all messages
-    writeBeastMessage(&Modes.beast_verbatim_out, mm->timestampMsg, mm->signalLevel, mm->verbatim, mm->msgbits / 8);
+    writeBeastMessage(&Modes.beast_verbatim_local_out, mm->timestampMsg, mm->signalLevel, mm->verbatim, mm->msgbits / 8);
 }
 
 static void modesSendBeastCookedOutput(struct modesMessage *mm, struct aircraft *a) {

--- a/net_io.h
+++ b/net_io.h
@@ -60,6 +60,8 @@ struct client {
     int    buflen;                       // Amount of data on buffer
     char   buf[MODES_CLIENT_BUF_SIZE+1]; // Read buffer
     int    modeac_requested;             // 1 if this Beast output connection has asked for A/C
+    int    verbatim_requested;           // 1 if this Beast output connection has asked for verbatim mode
+    int    local_requested;              // 1 if this Beast output connection has asked for local-only mode
 };
 
 // Common writer state for all output sockets of one type


### PR DESCRIPTION
As an implementation detail, whenever 'L' is enabled, 'V' (verbatim) is also implicitly enabled. (Clients should not rely on this as it will probably change in the future -- they should request both local and verbatim mode if they do want both)

See #202 for background.