### PR TITLE
Add METAR overlay

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -117,6 +117,10 @@
 						<div class="settingsText">NEXRAD Weather</div>
 					</div>
 					<div class="settingsOptionContainer">
+						<div class="settingsCheckbox" id="metar_checkbox"></div>
+						<div class="settingsText">METARs</div>
+					</div>
+					<div class="settingsOptionContainer">
 						<div class="settingsCheckbox" id="sitepos_checkbox"></div>
 						<div class="settingsText">Site Position and Range Rings</div>
 					</div>

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -930,6 +930,8 @@ function initialize_map() {
                 })
         });
 
+        var metarLayer = createMetarLayer();
+
         layers.push(new ol.layer.Group({
                 title: 'Overlays',
                 layers: [
@@ -950,6 +952,8 @@ function initialize_map() {
                                         features: PlaneTrailFeatures,
                                 })
                         }),
+
+                        metarLayer,
 
                         iconsLayer
                 ]
@@ -1042,12 +1046,15 @@ function initialize_map() {
                         }
                 }
         });
-    
+
         OLMap.getView().on('change:resolution', function(event) {
                 ZoomLvl = localStorage['ZoomLvl']  = OLMap.getView().getZoom();
                 for (var plane in Planes) {
                         Planes[plane].updateMarker(false);
                 };
+                if (metarLayer.getVisible()) {
+                        metarLayer.getSource().refresh();
+                }
         });
 
         OLMap.on(['click', 'dblclick'], function(evt) {
@@ -1097,6 +1104,7 @@ function initialize_map() {
     // handle the layer settings pane checkboxes
 	OLMap.once('postrender', function(e) {
 		toggleLayer('#nexrad_checkbox', 'nexrad');
+		toggleLayer('#metar_checkbox', 'metar');
 		toggleLayer('#sitepos_checkbox', 'site_pos');
 		toggleLayer('#actrail_checkbox', 'ac_trail');
 		toggleLayer('#acpositions_checkbox', 'ac_positions');


### PR DESCRIPTION
Uses the [metarjson](https://www.aviationweather.gov/help/webservice?page=metarjson) api from aviationweather.gov to overlay METARs.

![Screen Shot 2023-01-25 at 9 15 48 PM](https://user-images.githubusercontent.com/847739/214743200-a7e69971-1920-4afc-b231-33511ccec7c5.png)
