### PR TITLE
add option to force background tasks for --ifile

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -466,8 +466,8 @@ static void backgroundTasks(void) {
 
     uint64_t now = mstime();
 
-    if (Modes.sdr_type != SDR_IFILE) {
-        // don't run these if processing data from a file
+    if (Modes.sdr_type != SDR_IFILE || Modes.force_background_tasks) {
+        // don't run these if processing data from a file unless explicitly enabled
         icaoFilterExpire();
         trackPeriodicUpdate();
     }

--- a/dump1090.h
+++ b/dump1090.h
@@ -389,6 +389,7 @@ struct _Modes {                             // Internal state
     int   json_location_accuracy;    // Accuracy of location metadata: 0=none, 1=approx, 2=exact
     double faup_rate_multiplier;     // Multiplier to adjust rate of faup1090 messages emitted
     bool faup_upload_unknown_commb;  // faup1090: should we upload Comm-B messages that weren't in a recognized format?
+    bool force_background_tasks;     // override: used to enable background maintenance tasks when running with --ifile
 
     int   json_aircraft_history_next;
     struct {

--- a/sdr_ifile.c
+++ b/sdr_ifile.c
@@ -82,8 +82,9 @@ void ifileShowHelp()
     printf("      ifile-specific options (use with --ifile)\n");
     printf("\n");
     printf("--ifile <path>           read samples from given file ('-' for stdin)\n");
-    printf("--iformat <type>         set sample format (UC8, SC16, SC16Q11)\n");
-    printf("--throttle               process samples at the original capture speed\n");
+    printf("--ifile-format <type>    set sample format (UC8, SC16, SC16Q11)\n");
+    printf("--ifile-throttle         process samples at the original capture speed\n");
+    printf("--ifile-enable-bg-tasks  enable timed background maintenance tasks for realtime processing");
     printf("\n");
 }
 
@@ -96,7 +97,7 @@ bool ifileHandleOption(int argc, char **argv, int *jptr)
         // implies --device-type ifile
         ifile.filename = strdup(argv[++j]);
         Modes.sdr_type = SDR_IFILE;
-    } else if (!strcmp(argv[j],"--iformat") && more) {
+    } else if (!strcmp(argv[j],"--ifile-format") && more) {
         ++j;
         if (!strcasecmp(argv[j], "uc8")) {
             ifile.input_format = INPUT_UC8;
@@ -109,8 +110,10 @@ bool ifileHandleOption(int argc, char **argv, int *jptr)
                     argv[j]);
             return false;
         }
-    } else if (!strcmp(argv[j],"--throttle")) {
+    } else if (!strcmp(argv[j],"--ifile-throttle")) {
         ifile.throttle = true;
+    } else if (!strcmp(argv[j],"--ifile-enable-bg-tasks")) {
+        Modes.force_background_tasks = true;
     } else {
         return false;
     }


### PR DESCRIPTION
Just a few lines of code to add the ability to enable background tasks when using `--ifile` as input. Also tried to streamline the existing options by prefixing them with `ifile`, not sure if that's the right direction though.

Please refer to #228 for more detailed discussion about the problem at hand.