### PR TITLE
Fix incorrect `calloc()` parameter order

### DIFF
--- a/adaptive.c
+++ b/adaptive.c
@@ -195,7 +195,7 @@ void adaptive_init()
     adaptive_burst_window_remaining = adaptive_samples_per_window;
     adaptive_burst_window_counter = 0;
 
-    adaptive_range_radix = calloc(sizeof(unsigned), 65536);
+    adaptive_range_radix = calloc(65536, sizeof(unsigned));
     adaptive_range_state = RANGE_RESCAN_UP;
 
     // select and enforce gain limits

--- a/net_io.c
+++ b/net_io.c
@@ -104,7 +104,7 @@ struct net_service *serviceInit(const char *descr, struct net_writer *writer, he
 {
     struct net_service *service;
 
-    if (!(service = calloc(sizeof(*service), 1))) {
+    if (!(service = calloc(1, sizeof(*service)))) {
         fprintf(stderr, "Out of memory allocating service %s\n", descr);
         exit(1);
     }


### PR DESCRIPTION
In two instances, the paramter order for `calloc()` calls are reversed, with the element size in the first parameter and the count in the second. When building under Fedora rawhide with gcc 14, this is flagged as an error.