### PR TITLE
Add missing build package in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ many other Linux or Unix-like systems.
 ## Building under bullseye, buster, or stretch
 
 ```bash
-$ sudo apt-get install build-essential fakeroot debhelper librtlsdr-dev pkg-config libncurses5-dev libbladerf-dev libhackrf-dev liblimesuite-dev libsoapysdr-dev
+$ sudo apt-get install build-essential fakeroot debhelper librtlsdr-dev pkg-config libncurses5-dev libbladerf-dev libhackrf-dev liblimesuite-dev libsoapysdr-dev devscripts
 $ ./prepare-build.sh bullseye    # or buster, or stretch
 $ cd package-bullseye            # or buster, or stretch
 $ dpkg-buildpackage -b --no-sign


### PR DESCRIPTION
Hi

I was building the project under raspberry pi os bullseye (debian for raspberry pi).

```sh
lukasz@rpi-fat:~/dump1090 $ ./prepare-build.sh bullseye
Updating changelog for bullseye backport build
./prepare-build.sh: 48: dch: not found
```

debchange (abbreviation dch) is located in `devscripts` package. Therefore, I propose to add the package to the list of requirements.