### PR TITLE
Reduce default network flush time

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -122,7 +122,7 @@ static void modesInitConfig(void) {
 
     Modes.net_heartbeat_interval = MODES_NET_HEARTBEAT_INTERVAL;
     Modes.net_output_flush_size = 1300;
-    Modes.net_output_flush_interval = 500;
+    Modes.net_output_flush_interval = 90;
 
     // adaptive
     Modes.adaptive_min_gain_db = 0;


### PR DESCRIPTION
The dump1090 network outputs don't offer timing guarantees or real-time timestamps, but it is still useful for aggregators to locally timestamp messages they receive from dump1090 on a best-effort basis. With lower message rates, 500 ms of flush interval can result in significant jitter for those timestamps.
Most installs send data only on the local network or non-metered internet connections.
If necessary this default can be adjusted via --net-ro-interval by users who require a longer flush interval for some reason.

Reduce the default flush time to 90 ms to reliably flush every 2nd demodulation buffer when talking to an SDR (50 ms loop) and every loop iteration when running network-only (100 ms loop).

fixes: https://github.com/flightaware/dump1090/issues/244