### PR TITLE
Fix compilation with GCC15

### DIFF
--- a/ais_charset.c
+++ b/ais_charset.c
@@ -1,3 +1,3 @@
 #include "ais_charset.h"
 
-char ais_charset[64] = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";
+char ais_charset[65] = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";

--- a/ais_charset.h
+++ b/ais_charset.h
@@ -1,6 +1,6 @@
 #ifndef AIS_CHARSET_H
 #define AIS_CHARSET_H
 
-extern char ais_charset[64];
+extern char ais_charset[65];
 
 #endif

--- a/interactive.c
+++ b/interactive.c
@@ -140,7 +140,7 @@ void interactiveShowData(void) {
     static bool need_clear = true;
     uint64_t now = mstime();
     char progress;
-    char spinner[4] = "|/-\\";
+    char spinner[5] = "|/-\\";
     int valid = 0;
     double signalMax = -100.0;
     double signalMin = +100.0;


### PR DESCRIPTION
This fixes https://github.com/flightaware/dump1090/issues/257

GCC15 introduces new warnings, which are mandatory.

```
x86_64-pc-linux-gnu-gcc  -I. -D_POSIX_C_SOURCE=200112L -DMODES_DUMP1090_VERSION=\"unknown\" -DMODES_DUMP1090_VARIANT=\"dump1090-fa\" -D_DEFAULT_SOURCE -DENABLE_CPUFEATURES -Icpu_features/include -DSTARCH_MIX_X86 -march=native -mfpmath=sse,387 -mtune=intel -O3 -frecord-gcc-switches -fomit-frame-pointer -malign-data=abi -mtls-dialect=gnu2 -pipe -std=c11 -fno-common -Wall -Wmissing-declarations  -Wformat-signedness -W -c stats.c -o stats.o
interactive.c: In Funktion »interactiveShowData«:
interactive.c:143:23: Warnung: Initialisierer-Zeichenkette für Array von »char« schneidet NUL-Terminator ab, aber dem Ziel fehlt das »nonstring«-Attribut (5 Zeichen passen nicht in 4 verfügbare) [-Wunterminated-string-initialization]
  143 |     char spinner[4] = "|/-\\";
      |                       ^~~~~~~
```

```
x86_64-pc-linux-gnu-gcc  -I. -D_POSIX_C_SOURCE=200112L -DMODES_DUMP1090_VERSION=\"unknown\" -DMODES_DUMP1090_VARIANT=\"dump1090-fa\" -D_DEFAULT_SOURCE -DENABLE_CPUFEATURES -Icpu_features/include -DSTARCH_MIX_X86 -march=native -mfpmath=sse,387 -mtune=intel -O3 -frecord-gcc-switches -fomit-frame-pointer -malign-data=abi -mtls-dialect=gnu2 -pipe -std=c11 -fno-common -Wall -Wmissing-declarations  -Wformat-signedness -W -c ais_charset.c -o ais_charset.o
ais_charset.c:3:24: Warnung: Initialisierer-Zeichenkette für Array von »char« schneidet NUL-Terminator ab, aber dem Ziel fehlt das »nonstring«-Attribut (65 Zeichen passen nicht in 64 verfügbare) [-Wunterminated-string-initialization]
    3 | char ais_charset[64] = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
