### PR TITLE
Update style.css

### DIFF
--- a/public_html/style.css
+++ b/public_html/style.css
@@ -62,6 +62,7 @@ body {
 
 #planes_table {
     overflow-x: scroll;
+    padding-bottom: 30px;
 }
 
 .columnOptionContainer {


### PR DESCRIPTION
Add space on the bottom of the planes table to prevent horizontal scrollbars from covering the last entry. This issue affects Safari, tested on MacOS.