### PR TITLE
Add nonstring attribute to fix Clang build errors

### DIFF
--- a/ais_charset.c
+++ b/ais_charset.c
@@ -1,3 +1,3 @@
 #include "ais_charset.h"
 
-char ais_charset[64] = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";
+char ais_charset[64] __attribute__ ((nonstring)) = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_ !\"#$%&'()*+,-./0123456789:;<=>?";

--- a/interactive.c
+++ b/interactive.c
@@ -140,7 +140,7 @@ void interactiveShowData(void) {
     static bool need_clear = true;
     uint64_t now = mstime();
     char progress;
-    char spinner[4] = "|/-\\";
+    char spinner[4] __attribute__ ((nonstring)) = "|/-\\";
     int valid = 0;
     double signalMax = -100.0;
     double signalMin = +100.0;


### PR DESCRIPTION
## Summary
- Adds `__attribute__((nonstring))` to two character arrays that are intentionally sized without room for a null terminator
- Fixes build failure with modern Clang when `-Werror` is enabled

## Details
The `ais_charset` (64-char AIS lookup table) and `spinner` (4-char animation) arrays are used as raw byte lookup tables, not C strings. Clang's `-Wunterminated-string-initialization` warning (promoted to error by `-Werror`) causes the build to fail.

The `nonstring` attribute is the idiomatic fix—it documents intent and is more targeted than disabling the warning globally via compiler flags.

## Test plan
- [x] Verified build succeeds with Clang 21