### PR TITLE
More URL parameters to control map appearance

### DIFF
--- a/public_html/README.md
+++ b/public_html/README.md
@@ -14,26 +14,49 @@ Examples:
 
     http://<ip_address>/skyaware/?ringCount=3&ringBaseDistance=100&ringInterval=50
 
-| Parameter | Possible Values |
-| :---------: | :---------: |
-| banner  | show/hide |
-| altitudeChart | show/hide |
-| aircraftTrails | show/hide |
-| map | show/hide | 
-| sidebar | show/hide | 
-| zoomOut | 0 - 5 | 
-| zoomIn | 0 - 5 | 
-| moveNorth | 0 - 5 | 
-| moveSouth | 0 - 5 | 
-| moveWest | 0 - 5 | 
-| moveEast | 0 - 5 | 
-| displayUnits | nautical/imperial/metric |
-| rangeRings | show/hide | 
-| ringCount | integer |
-| ringBaseDistance | integer |
-| ringInterval | integer |
+| Parameter | Possible Values | Description |
+| :-------- | :-------------- | :---------- |
+| banner | show/hide | Show or hide the header banner |
+| altitudeChart | show/hide | Show or hide the altitude chart |
+| aircraftTrails | show/hide | Show or hide all aircraft trails |
+| aircraftLabels | show/hide | Show or hide flight-number labels on map icons |
+| aircraftLabelDetails | show/hide | When labels are shown, also display ICAO aircraft type code on a second line |
+| map | show/hide | Show or hide the map panel |
+| sidebar | show/hide | Show or hide the sidebar |
+| zoomOut | 0 - 5 | Zoom out by a relative amount |
+| zoomIn | 0 - 5 | Zoom in by a relative amount |
+| zoom | 1 - 20 | Set an absolute OpenLayers zoom level |
+| moveNorth | 0 - 5 | Pan the map north |
+| moveSouth | 0 - 5 | Pan the map south |
+| moveWest | 0 - 5 | Pan the map west |
+| moveEast | 0 - 5 | Pan the map east |
+| lat | -90 to 90 | Center the map at this latitude (must be used together with `lon`) |
+| lon | -180 to 180 | Center the map at this longitude (must be used together with `lat`) |
+| baseLayer | layer name | Select the active base map layer by name (see layer names below) |
+| displayUnits | nautical/imperial/metric | Set the display units |
+| rangeRings | show/hide | Show or hide range rings |
+| ringCount | integer | Number of range rings |
+| ringBaseDistance | integer | Radius of the innermost ring |
+| ringInterval | integer | Distance between rings |
 
+### Base layer names for `baseLayer`
 
+| Name | Description |
+| :--- | :---------- |
+| osm | OpenStreetMap |
+| esri_satellite | ESRI Satellite imagery |
+| esri_topo | ESRI Topographic |
+| esri_street | ESRI Street |
+| carto_dark_all | CARTO Dark (with labels) |
+| carto_dark_nolabels | CARTO Dark (no labels) |
+| carto_light_all | CARTO Light (with labels) |
+| carto_light_nolabels | CARTO Light (no labels) |
+| bing_aerial | Bing Aerial (requires Bing API key in config.js) |
+| bing_roads | Bing Roads (requires Bing API key in config.js) |
+| VFR_Sectional | FAA VFR Sectional Chart (requires FAALayers enabled) |
+| IFR_AreaLow | FAA IFR Area Low (requires FAALayers enabled) |
+| IFR_High | FAA IFR High (requires FAALayers enabled) |
+| VFR_Terminal | FAA VFR Terminal Chart (requires FAALayers enabled) |
 
 ## New World/US/Europe Basemaps and Overlays
 

--- a/public_html/README.md
+++ b/public_html/README.md
@@ -33,6 +33,7 @@ Examples:
 | lat | -90 to 90 | Center the map at this latitude (must be used together with `lon`) |
 | lon | -180 to 180 | Center the map at this longitude (must be used together with `lat`) |
 | baseLayer | layer name | Select the active base map layer by name (see layer names below) |
+| cartoApiKey | API key string | CARTO API key appended to the CARTO base layer tile requests (overrides `CartoAPIKey` in config.js) |
 | displayUnits | nautical/imperial/metric | Set the display units |
 | rangeRings | show/hide | Show or hide range rings |
 | ringCount | integer | Number of range rings |
@@ -47,10 +48,10 @@ Examples:
 | esri_satellite | ESRI Satellite imagery |
 | esri_topo | ESRI Topographic |
 | esri_street | ESRI Street |
-| carto_dark_all | CARTO Dark (with labels) |
-| carto_dark_nolabels | CARTO Dark (no labels) |
-| carto_light_all | CARTO Light (with labels) |
-| carto_light_nolabels | CARTO Light (no labels) |
+| carto_dark_all | CARTO Dark (with labels) (requires `cartoApiKey`) |
+| carto_dark_nolabels | CARTO Dark (no labels) (requires `cartoApiKey`) |
+| carto_light_all | CARTO Light (with labels) (requires `cartoApiKey`) |
+| carto_light_nolabels | CARTO Light (no labels) (requires `cartoApiKey`) |
 | bing_aerial | Bing Aerial (requires Bing API key in config.js) |
 | bing_roads | Bing Roads (requires Bing API key in config.js) |
 | VFR_Sectional | FAA VFR Sectional Chart (requires FAALayers enabled) |

--- a/public_html/config.js
+++ b/public_html/config.js
@@ -121,6 +121,15 @@ FAALayers = true;
 //
 BingMapsAPIKey = null;
 
+// CARTO basemaps now require an API key. Provide a default key here, or
+// supply one at runtime via the "cartoApiKey" URL parameter (which overrides
+// this value). Obtain a key at https://carto.com/basemaps/apikey/
+//
+// Be sure to quote your key:
+//   CartoAPIKey = "your key here";
+//
+CartoAPIKey = null;
+
 // Turn on display of extra Mode S EHS / ADS-B v1/v2 data
 // This is not polished yet (and so is disabled by default),
 // currently it's just a data dump of the new fields with no UX work.

--- a/public_html/index.html
+++ b/public_html/index.html
@@ -168,6 +168,10 @@
 						<div class="settingsCheckbox" id="aircraft_label_checkbox"></div>
 						<div class="settingsText">Show Aircraft Labels</div>
 					</div>
+					<div class="settingsOptionContainer">
+						<div class="settingsCheckbox" id="aircraft_label_details_checkbox"></div>
+						<div class="settingsText">Aircraft Label Details</div>
+					</div>
 				</div>
 				<div id="range_ring_column" class="settingsOptionContainer">
 					<div class="infoBlockTitleText">Range Rings</div>

--- a/public_html/layers.js
+++ b/public_html/layers.js
@@ -23,6 +23,20 @@ function createBaseLayers() {
         var us = [];
         var europe = [];
 
+        // CARTO basemaps now require an API key. Prefer the "cartoApiKey" URL
+        // parameter, falling back to CartoAPIKey from config.js. The key is
+        // baked into the tile URLs so it is used whenever a CARTO base layer
+        // is selected.
+        var cartoKey = new URLSearchParams(window.location.search).get('cartoApiKey')
+                || (typeof CartoAPIKey !== 'undefined' ? CartoAPIKey : null);
+        function cartoUrl(style) {
+                var url = "https://{a-z}.basemaps.cartocdn.com/" + style + "/{z}/{x}/{y}.png";
+                if (cartoKey) {
+                        url += "?key=" + encodeURIComponent(cartoKey);
+                }
+                return url;
+        }
+
         world.push(new ol.layer.Tile({
                 source: new ol.source.OSM(),
                 name: 'osm',
@@ -62,7 +76,7 @@ function createBaseLayers() {
 
         world.push(new ol.layer.Tile({
                 source: new ol.source.OSM({
-                        "url" : "https://{a-z}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+                        "url" : cartoUrl('dark_all'),
                         "attributions" : 'Courtesy of <a href="https://carto.com">CARTO.com</a>'
                                + ' using data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
                 }),
@@ -73,7 +87,7 @@ function createBaseLayers() {
 
         world.push(new ol.layer.Tile({
                 source: new ol.source.OSM({
-                        "url" : "https://{a-z}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
+                        "url" : cartoUrl('dark_nolabels'),
                         "attributions" : 'Courtesy of <a href="https://carto.com">CARTO.com</a>'
                                + ' using data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
                 }),
@@ -84,7 +98,7 @@ function createBaseLayers() {
 
         world.push(new ol.layer.Tile({
                 source: new ol.source.OSM({
-                        "url" : "https://{a-z}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
+                        "url" : cartoUrl('light_all'),
                         "attributions" : 'Courtesy of <a href="https://carto.com">CARTO.com</a>'
                                + ' using data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
                 }),
@@ -95,7 +109,7 @@ function createBaseLayers() {
 
         world.push(new ol.layer.Tile({
                 source: new ol.source.OSM({
-                        "url" : "https://{a-z}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png",
+                        "url" : cartoUrl('light_nolabels'),
                         "attributions" : 'Courtesy of <a href="https://carto.com">CARTO.com</a>'
                                + ' using data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
                 }),

--- a/public_html/planeObject.js
+++ b/public_html/planeObject.js
@@ -451,6 +451,15 @@ PlaneObject.prototype.getAltitudeColor = function(altitude) {
         return [h, s, l];
 }
 
+PlaneObject.prototype.getLabelText = function() {
+        if (this.flight === null) return null;
+        var text = this.flight.trim();
+        if (AircraftLabelDetails && this.icaotype) {
+                text += '\n' + this.icaotype.trim();
+        }
+        return text;
+};
+
 PlaneObject.prototype.updateIcon = function() {
         var scaleFactor = Math.max(0.2, Math.min(1.2, 0.15 * Math.pow(1.25, ZoomLvl))).toFixed(1);
 
@@ -472,7 +481,7 @@ PlaneObject.prototype.updateIcon = function() {
         //var transparentBorderWidth = (32 / baseMarker.scale / scaleFactor).toFixed(1);
 
         var svgKey = col + '!' + outline + '!' + baseMarker.svg + '!' + add_stroke + "!" + scaleFactor;
-        var styleKey = opacity + '!' + rotation + '!' + AircraftLabels;
+        var styleKey = opacity + '!' + rotation + '!' + AircraftLabels + '!' + AircraftLabelDetails;
 
         // New icon or marker change
         if (this.markerStyle === null || this.markerIcon === null || this.markerSvgKey != svgKey) {
@@ -492,11 +501,12 @@ PlaneObject.prototype.updateIcon = function() {
 
                 this.markerIcon = icon;
 
-                if (AircraftLabels && this.flight != null) {
+                var labelText = AircraftLabels ? this.getLabelText() : null;
+                if (labelText !== null) {
                         this.markerStyle = new ol.style.Style({
                                 image: this.markerIcon,
                                 text: new ol.style.Text({
-                                        text: this.flight.trim(),
+                                        text: labelText,
                                         fill: new ol.style.Fill({color: 'white'}),
                                         backgroundFill: new ol.style.Stroke({color: 'rgba(0, 47, 93, 0.8'}),
                                         textAlign: 'center',
@@ -532,11 +542,12 @@ PlaneObject.prototype.updateIcon = function() {
                         this.staticIcon.setOpacity(opacity);
                 }
 
-                if (AircraftLabels && this.flight != null) {
+                var labelText = AircraftLabels ? this.getLabelText() : null;
+                if (labelText !== null) {
                         this.markerStyle = new ol.style.Style({
                                 image: this.markerIcon,
                                 text: new ol.style.Text({
-                                        text: this.flight.trim(),
+                                        text: labelText,
                                         fill: new ol.style.Fill({color: 'white'}),
                                         backgroundFill: new ol.style.Stroke({color: 'rgba(0, 47, 93, 0.8)'}),
                                         textAlign: 'center',

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -63,6 +63,7 @@ var altitude_slider = null;
 var speed_slider = null;
 
 var AircraftLabels = false;
+var AircraftLabelDetails = false;
 
 // piaware vs flightfeeder
 var isFlightFeeder = false;
@@ -400,6 +401,10 @@ function initialize() {
                 toggleAircraftLabels(true);
         });
 
+        $('#aircraft_label_details_checkbox').on('click', function() {
+                toggleAircraftLabelDetails(true);
+        });
+
         $('#altitude_checkbox').on('click', function() {
         	toggleAltitudeChart(true);
         });
@@ -475,6 +480,7 @@ function initialize() {
         toggleAllPlanes(false);
         toggleGroupByDataType(false);
         toggleAircraftLabels(false);
+        toggleAircraftLabelDetails(false);
         toggleAllColumns(false);
         toggleADSBAircraft(false);
         toggleUATAircraft(false);
@@ -782,7 +788,8 @@ function applyUrlQueryStrings() {
         'zoom',
         'lat',
         'lon',
-        'aircraftLabels'
+        'aircraftLabels',
+        'aircraftLabelDetails'
     ]
 
     var needReset = false;
@@ -868,6 +875,14 @@ function applyUrlQueryStrings() {
     if (params.get('aircraftLabels') === 'hide') {
         localStorage.setItem('showAircraftLabels', 'deselected');
         toggleAircraftLabels(false);
+    }
+    if (params.get('aircraftLabelDetails') === 'show') {
+        localStorage.setItem('aircraftLabelDetails', 'selected');
+        toggleAircraftLabelDetails(false);
+    }
+    if (params.get('aircraftLabelDetails') === 'hide') {
+        localStorage.setItem('aircraftLabelDetails', 'deselected');
+        toggleAircraftLabelDetails(false);
     }
     if (params.get('baseLayer')) {
         setBaseLayer(params.get('baseLayer'));
@@ -2035,6 +2050,27 @@ function toggleAircraftLabels(switchToggle) {
 	}
 
         localStorage.setItem('showAircraftLabels', showAircraftLabels);
+}
+
+function toggleAircraftLabelDetails(switchToggle) {
+	if (typeof localStorage['aircraftLabelDetails'] === 'undefined') {
+		localStorage.setItem('aircraftLabelDetails', 'deselected');
+	}
+
+	var aircraftLabelDetails = localStorage.getItem('aircraftLabelDetails');
+	if (switchToggle === true) {
+		aircraftLabelDetails = (aircraftLabelDetails === 'deselected') ? 'selected' : 'deselected';
+	}
+
+	if (aircraftLabelDetails === 'deselected') {
+		AircraftLabelDetails = false;
+		$('#aircraft_label_details_checkbox').removeClass('settingsCheckboxChecked');
+	} else {
+		AircraftLabelDetails = true;
+		$('#aircraft_label_details_checkbox').addClass('settingsCheckboxChecked');
+	}
+
+	localStorage.setItem('aircraftLabelDetails', aircraftLabelDetails);
 }
 
 function toggleAllPlanes(switchToggle) {

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -777,7 +777,11 @@ function applyUrlQueryStrings() {
         'rangeRings',
         'ringCount',
         'ringBaseDistance',
-        'ringInterval'
+        'ringInterval',
+        'baseLayer',
+        'zoom',
+        'lat',
+        'lon'
     ]
 
     var needReset = false;
@@ -855,6 +859,28 @@ function applyUrlQueryStrings() {
     }
     if (params.get('ringInterval')) {
         setRingInterval(params.get('ringInterval'));
+    }
+    if (params.get('baseLayer')) {
+        setBaseLayer(params.get('baseLayer'));
+    }
+    if (params.get('zoom')) {
+        var z = parseFloat(params.get('zoom'));
+        if (!isNaN(z) && z >= 1 && z <= 20) {
+            ZoomLvl = z;
+            localStorage['ZoomLvl'] = ZoomLvl;
+            OLMap.getView().setZoom(ZoomLvl);
+        }
+    }
+    if (params.get('lat') !== null && params.get('lon') !== null) {
+        var lat = parseFloat(params.get('lat'));
+        var lon = parseFloat(params.get('lon'));
+        if (!isNaN(lat) && !isNaN(lon) && lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180) {
+            CenterLat = lat;
+            CenterLon = lon;
+            localStorage['CenterLat'] = CenterLat;
+            localStorage['CenterLon'] = CenterLon;
+            OLMap.getView().setCenter(ol.proj.fromLonLat([CenterLon, CenterLat]));
+        }
     }
 }
 
@@ -2574,7 +2600,14 @@ function hideBanner() {
     updateMapSize();
 }
 
-// Helper function to restrict the range of the inputs
+function setBaseLayer(name) {
+    ol.control.LayerSwitcher.forEachRecursive(layerGroup, function(lyr) {
+        if (lyr.get('type') === 'base') {
+            lyr.setVisible(lyr.get('name') === name);
+        }
+    });
+}
+
 function restrictUrlRequest(c) {
     let v = parseFloat(c);
     if (v < 0) {

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -781,7 +781,8 @@ function applyUrlQueryStrings() {
         'baseLayer',
         'zoom',
         'lat',
-        'lon'
+        'lon',
+        'aircraftLabels'
     ]
 
     var needReset = false;
@@ -859,6 +860,14 @@ function applyUrlQueryStrings() {
     }
     if (params.get('ringInterval')) {
         setRingInterval(params.get('ringInterval'));
+    }
+    if (params.get('aircraftLabels') === 'show') {
+        localStorage.setItem('showAircraftLabels', 'selected');
+        toggleAircraftLabels(false);
+    }
+    if (params.get('aircraftLabels') === 'hide') {
+        localStorage.setItem('showAircraftLabels', 'deselected');
+        toggleAircraftLabels(false);
     }
     if (params.get('baseLayer')) {
         setBaseLayer(params.get('baseLayer'));


### PR DESCRIPTION
I set up a home-office wall display screen showing the Piaware/dump1090 web map. To make the map look better as a non-interactive wall display, I needed to expose some extra controls over the visual options that weren't currently configurable via URL parameters.

This PR adds a few URL parameters for visual controls. Other than `aircraftLabelDetails`, which is new, all of these change just expose existing options as URL parameters.

- `aircraftLabels`: toggle labels on/off
- `aircraftLabelDetails`: add ICAO aircraft type to the labels
- `zoom`: set absolute zoom level
- `lat`/`lon`: set map centerpoint latitude/longitude
- `baseLayer`: pre-select a specific map base layer
- `cartoApiKey`: CARTO API key for the CARTO base layers

CARTO basemaps now require an API key, which broke the existing CARTO base layers. The `cartoApiKey` parameter is appended to the CARTO raster tile requests so those layers work again when a key is supplied (it can also be set via `CartoAPIKey` in `config.js`, with the URL parameter taking precedence).