### PR TITLE
fix: add --max-clients option to limit concurrent network connections

### DIFF
--- a/dump1090.c
+++ b/dump1090.c
@@ -401,6 +401,8 @@ static void showHelp(void)
 "--net-verbatim           Make output connections default to verbatim mode\n"
 "                           (forward all messages without correction)\n"
 "--forward-mlat           Allow forwarding of received mlat results\n"
+"--max-clients <n>        Maximum number of simultaneous network clients\n"
+"                           (default: 0 = unlimited)\n"
 "\n"
 // ------ 80 char limit ----------------------------------------------------------|
 "      Stats and json output\n"
@@ -696,6 +698,8 @@ int main(int argc, char **argv) {
             Modes.net_verbatim = 1;
         } else if (!strcmp(argv[j],"--forward-mlat")) {
             Modes.forward_mlat = 1;
+        } else if (!strcmp(argv[j],"--max-clients") && more) {
+            Modes.max_clients = atoi(argv[++j]);
         } else if (!strcmp(argv[j],"--onlyaddr")) {
             Modes.onlyaddr = 1;
         } else if (!strcmp(argv[j],"--metric")) {

--- a/dump1090.h
+++ b/dump1090.h
@@ -328,6 +328,7 @@ struct _Modes {                             // Internal state
     char           aneterr[ANET_ERR_LEN];
     struct net_service *services;    // Active services
     struct client *clients;          // Our clients
+    int client_count;                // Number of active clients
 
     struct net_service *beast_verbatim_service;        // Beast-format output service, verbatim mode
     struct net_service *beast_verbatim_local_service;  // Beast-format output service, verbatim+local mode
@@ -369,6 +370,7 @@ struct _Modes {                             // Internal state
     int   net_sndbuf_size;           // TCP output buffer size (64Kb * 2^n)
     int   net_verbatim;              // if true, Beast output connections default to verbatim mode
     int   forward_mlat;              // allow forwarding of mlat messages to output ports
+    int   max_clients;               // maximum number of simultaneous network clients (0 = unlimited)
     int   quiet;                     // Suppress stdout
     uint32_t show_only;              // Only show messages from this ICAO
     int   interactive;               // Interactive mode

--- a/net_io.c
+++ b/net_io.c
@@ -162,6 +162,7 @@ struct client *createGenericClient(struct net_service *service, int fd)
     c->verbatim_requested = (service == Modes.beast_verbatim_service || service == Modes.beast_verbatim_local_service);
     c->local_requested = (service == Modes.beast_verbatim_local_service);
     Modes.clients = c;
+    Modes.client_count++;
 
     moveNetClient(c, service);
 
@@ -306,6 +307,10 @@ static struct client * modesAcceptClients(void) {
         int i;
         for (i = 0; i < s->listener_count; ++i) {
             while ((fd = anetTcpAccept(Modes.aneterr, s->listener_fds[i])) >= 0) {
+                if (Modes.max_clients > 0 && Modes.client_count >= Modes.max_clients) {
+                    close(fd);
+                    continue;
+                }
                 createSocketClient(s, fd);
             }
         }
@@ -331,6 +336,7 @@ static void modesCloseClient(struct client *c) {
 
     close(c->fd);
     c->service->connections--;
+    Modes.client_count--;
 
     // mark it as inactive and ready to be freed
     c->fd = -1;


### PR DESCRIPTION
## Summary

Adds a configurable `--max-clients` option to limit the number of simultaneous TCP clients connecting to dump1090.

## Changes

- **`dump1090.h`**: Added `max_clients` and `client_count` fields to the Modes struct
- **`dump1090.c`**: Added `--max-clients <n>` CLI option parsing and help text
- **`net_io.c`**: 
  - Track global client count via `Modes.client_count`
  - Reject new connections in `modesAcceptClients()` when `Modes.client_count >= Modes.max_clients`

## Usage

```
dump1090 --net --max-clients 100
```

Default is `0` (unlimited), preserving backward compatibility.

## Motivation

Without a connection limit, an attacker can open thousands of TCP connections, exhausting memory and file descriptors. Each connection consumes ~1KB of memory and is polled on every network cycle, causing CPU degradation and service unavailability.

Fixes #298