### PR TITLE
fix: add NULL checks after strtok in handleFaupCommand

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -1148,6 +1148,8 @@ static int handleFaupCommand(struct client *c, char *p) {
     while (msg_field != NULL) {
         if (!strcmp(msg_field, "upload_rate_multiplier")) {
             msg_field = strtok (NULL, "\t");
+            if (msg_field == NULL)
+                break;
             multiplier = atof(msg_field);
 
             // Sanity check on multiplier value
@@ -1163,6 +1165,8 @@ static int handleFaupCommand(struct client *c, char *p) {
 
         if (!strcmp(msg_field, "upload_unknown_commb")) {
             msg_field = strtok (NULL, "\t");
+            if (msg_field == NULL)
+                break;
             unsigned enable = atoi(msg_field);
             fprintf(stderr, "handleFaupCommand(): %s upload of unknown Comm-B messages\n", enable ? "Enabling" : "Disabling");
             Modes.faup_upload_unknown_commb = enable;


### PR DESCRIPTION
## Summary

Adds NULL checks after `strtok(NULL, "\t")` calls in `handleFaupCommand` to prevent a crash when a client sends a field name without a corresponding value.

## Changes

- **`net_io.c`**: Added `if (msg_field == NULL) break;` after each `strtok` call that retrieves a value for `upload_rate_multiplier` and `upload_unknown_commb`

## Motivation

A client connecting to the FAUP command port can send `upload_rate_multiplier\t` (with tab but no value). The `strtok` call returns NULL, which is passed to `atof()`, causing undefined behavior (typically a segfault).

Fixes #302