### PR TITLE
fix: check realloc return value in generateAircraftJson

### DIFF
--- a/net_io.c
+++ b/net_io.c
@@ -1862,8 +1862,15 @@ char *generateAircraftJson(const char *url_path, int *len) {
         if ((p + 10) >= end) { // +10 to leave some space for the final line
             // overran the buffer
             int used = line_start - buf;
+            char *newbuf;
             buflen *= 2;
-            buf = (char *) realloc(buf, buflen);
+            newbuf = (char *) realloc(buf, buflen);
+            if (!newbuf) {
+                free(buf);
+                *len = 0;
+                return NULL;
+            }
+            buf = newbuf;
             p = buf+used;
             end = buf + buflen;
             goto retry;


### PR DESCRIPTION
## Summary

Checks the return value of `realloc` in `generateAircraftJson` to prevent a NULL pointer dereference on out-of-memory conditions.

## Changes

- **`net_io.c`**: Save the old buffer pointer before `realloc`. If `realloc` returns NULL, free the old buffer and return NULL to the caller instead of crashing.

## Motivation

When the JSON output buffer needs to grow, the code called `realloc` without checking the return value. If memory is exhausted, `realloc` returns NULL and the subsequent pointer assignments cause a segfault. This is more likely on memory-constrained devices or when tracking a very large number of aircraft.

Fixes #305