### PR TITLE
fix: use HTTPS for NEXRAD tiles and airframes.org form

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -44,7 +44,7 @@
 		-->
 		<form id="horrible_hack" class="hidden">
 		</form>
-		<form id="airframes_post" method="POST" action="http://www.airframes.org/" target="_blank" class="hidden">
+		<form id="airframes_post" method="POST" action="https://www.airframes.org/" target="_blank" class="hidden">
 			<input type="hidden" name="reg1" value="">
 			<input type="hidden" name="selcal" value="">
 			<input id="airframes_post_icao" type="hidden" name="ica024" value="">

--- a/public_html/layers.js
+++ b/public_html/layers.js
@@ -171,8 +171,8 @@ function createBaseLayers() {
                 // re-build the source to force a refresh of the nexrad tiles
                 var now = new Date().getTime();
                 nexrad.setSource(new ol.source.XYZ({
-                        url : 'http://mesonet{1-3}.agron.iastate.edu/cache/tile.py/1.0.0/nexrad-n0q-900913/{z}/{x}/{y}.png?_=' + now,
-                        attributions: 'NEXRAD courtesy of <a href="http://mesonet.agron.iastate.edu/">IEM</a>'
+                        url : 'https://mesonet.agron.iastate.edu/cache/tile.py/1.0.0/nexrad-n0q-900913/{z}/{x}/{y}.png?_=' + now,
+                        attributions: 'NEXRAD courtesy of <a href="https://mesonet.agron.iastate.edu/">IEM</a>'
                 }));
         };
 


### PR DESCRIPTION
## Summary

Upgrades two external resource loads from HTTP to HTTPS to prevent man-in-the-middle manipulation.

## Changes

- **`layers.js:174`**: NEXRAD weather tile URL changed from `http://mesonet{1-3}.agron.iastate.edu/...` to `https://mesonet.agron.iastate.edu/...`
- **`index.html:47`**: airframes.org form action changed from `http://www.airframes.org/` to `https://www.airframes.org/`

## Motivation

NEXRAD tiles loaded over HTTP could be manipulated by a MITM attacker to hide or fabricate weather data. The airframes.org form sent the tracked aircraft ICAO code in cleartext. Both servers support HTTPS.

Fixes #303
Fixes #304