### PR TITLE
fix: defensive hardening across C backend

### DIFF
--- a/demod_2400.c
+++ b/demod_2400.c
@@ -118,7 +118,10 @@ void demodulate2400(struct mag_buf *mag)
     int bestscore, bestphase;
 
     // maximum lookahead we use
-    assert(mag->overlap >= 19 + 1 + 269);
+    if (mag->overlap < 19 + 1 + 269) {
+        fprintf(stderr, "insufficient overlap for signal power measurement\n");
+        return;
+    }
 
     uint16_t *m = mag->data;
     uint32_t mlen = mag->validLength - mag->overlap;

--- a/net_io.c
+++ b/net_io.c
@@ -2079,6 +2079,7 @@ char *generateStatsJson(const char *url_path, int *len) {
 char *generateReceiverJson(const char *url_path, int *len)
 {
     char *buf = (char *) malloc(1024), *p = buf;
+    char *end = buf + 1024;
     int history_size;
 
     MODES_NOTUSED(url_path);
@@ -2089,7 +2090,7 @@ char *generateReceiverJson(const char *url_path, int *len)
     else
         history_size = HISTORY_SIZE;
 
-    p += sprintf(p, "{ " \
+    p = safe_snprintf(p, end, "{ " \
                  "\"version\" : \"%s\", "
                  "\"refresh\" : %.0f, "
                  "\"history\" : %d",
@@ -2097,19 +2098,19 @@ char *generateReceiverJson(const char *url_path, int *len)
 
     if (Modes.json_location_accuracy && (Modes.fUserLat != 0.0 || Modes.fUserLon != 0.0)) {
         if (Modes.json_location_accuracy == 1) {
-            p += sprintf(p, ", "                \
+            p = safe_snprintf(p, end, ", "                \
                          "\"lat\" : %.2f, "
                          "\"lon\" : %.2f",
                          Modes.fUserLat, Modes.fUserLon);  // round to 2dp - about 0.5-1km accuracy - for privacy reasons
         } else {
-            p += sprintf(p, ", "                \
+            p = safe_snprintf(p, end, ", "                \
                          "\"lat\" : %.6f, "
                          "\"lon\" : %.6f",
                          Modes.fUserLat, Modes.fUserLon);  // exact location
         }
     }
 
-    p += sprintf(p, " }\n");
+    p = safe_snprintf(p, end, " }\n");
 
     *len = (p - buf);
     return buf;
@@ -2324,6 +2325,9 @@ static void modesReadFromClient(struct client *c) {
                     if (0x1A == *p) {
                         p++;
                         eom++;
+                        if (eom > eod + MODES_LONG_MSG_BYTES) {
+                            break; // Sanity limit
+                        }
                     }
                 }
 

--- a/view1090.c
+++ b/view1090.c
@@ -187,6 +187,10 @@ int main(int argc, char **argv) {
             }
         } else if (!strcmp(argv[j], "--interactive-callsign-filter") && more) {
             Modes.interactive_callsign_filter = strdup(argv[++j]);
+            if (!Modes.interactive_callsign_filter) {
+                fprintf(stderr, "out of memory\n");
+                exit(1);
+            }
         } else if (!strcmp(argv[j], "--lat") && more) {
             Modes.fUserLat = atof(argv[++j]);
         } else if (!strcmp(argv[j],"--lon") && more) {


### PR DESCRIPTION
## Summary

Grouped low-severity defensive fixes across the C backend for security hardening.

## Changes

- **`net_io.c`**: `generateReceiverJson` — replace `sprintf` with `safe_snprintf` for bounds checking
- **`net_io.c`**: Beast escape scan — add sanity limit on `eom` growth to prevent excessive expansion
- **`view1090.c`**: Check `strdup` return value for OOM
- **`demod_2400.c`**: Replace `assert` with runtime check for signal power buffer overlap (asserts are compiled out with NDEBUG)

## Deferred

Some issues from the review were deferred as they are design decisions or already safe in practice:
- Unbounded buffer growth in JSON generation (controlled by aircraft count)
- Buffer-full discard behavior (intentional design)
- `strlen` on hex input (caller NUL-terminates)
- TOCTOU on json file write (mkstemp already used correctly)

Fixes #309