### PR TITLE
fix: defensive hardening across SkyAware frontend

### DIFF
--- a/public_html/formatter.js
+++ b/public_html/formatter.js
@@ -45,6 +45,26 @@ function format_track_long(track) {
 	return Math.round(track) + DEGREES + NBSP + "(" + TrackDirections[trackDir] + ")";
 }
 
+// Return altitude text without HTML
+function format_altitude_text(alt, displayUnits) {
+	if (alt === null) {
+		return "";
+	} else if (alt === "ground") {
+		return "ground";
+	}
+	return Math.round(convert_altitude(alt, displayUnits)).toLocaleString() + NBSP;
+}
+
+// Return vertical rate triangle character (no HTML)
+function format_vert_rate_triangle(vr) {
+	if (vr > 128) {
+		return UP_TRIANGLE;
+	} else if (vr < -128) {
+		return DOWN_TRIANGLE;
+	}
+	return NBSP;
+}
+
 // alt in feet
 function format_altitude_brief(alt, vr, displayUnits) {
 	var alt_text;

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -156,8 +156,12 @@ function processReceiverUpdate(data, receiver_source) {
 
                         // set flag image if available
                         if (ShowFlags && plane.icaorange.flag_image !== null) {
-                                $('img', plane.tr.cells[1]).attr('src', FlagPath + plane.icaorange.flag_image);
-                                $('img', plane.tr.cells[1]).attr('title', plane.icaorange.country);
+                                if (/^[a-zA-Z0-9_-]+\.png$/.test(plane.icaorange.flag_image)) {
+                                        $('img', plane.tr.cells[1]).attr('src', FlagPath + plane.icaorange.flag_image);
+                                        $('img', plane.tr.cells[1]).attr('title', plane.icaorange.country);
+                                } else {
+                                        $('img', plane.tr.cells[1]).css('display', 'none');
+                                }
                         } else {
                                 $('img', plane.tr.cells[1]).css('display', 'none');
                         }
@@ -1733,7 +1737,16 @@ function refreshTableInfo() {
                         tableplane.tr.cells[3].textContent = (tableplane.registration !== null ? tableplane.registration : "");
                         tableplane.tr.cells[4].textContent = (tableplane.icaotype !== null ? tableplane.icaotype : "");
                         tableplane.tr.cells[5].textContent = (tableplane.squawk !== null ? tableplane.squawk : "");
-                        tableplane.tr.cells[6].innerHTML = format_altitude_brief(tableplane.altitude, tableplane.vert_rate, DisplayUnits);
+                        {
+                                var cell = tableplane.tr.cells[6];
+                                cell.textContent = '';
+                                var altText = format_altitude_text(tableplane.altitude, DisplayUnits);
+                                cell.appendChild(document.createTextNode(altText));
+                                var vrSpan = document.createElement('span');
+                                vrSpan.className = 'verticalRateTriangle';
+                                vrSpan.textContent = format_vert_rate_triangle(tableplane.vert_rate);
+                                cell.appendChild(vrSpan);
+                        }
                         tableplane.tr.cells[7].textContent = format_speed_brief(tableplane.gs, DisplayUnits);
                         tableplane.tr.cells[8].textContent = format_vert_rate_brief(tableplane.vert_rate, DisplayUnits);
                         tableplane.tr.cells[9].textContent = format_distance_brief(tableplane.sitedist, DisplayUnits);
@@ -2577,7 +2590,7 @@ function hideBanner() {
 // Helper function to restrict the range of the inputs
 function restrictUrlRequest(c) {
     let v = parseFloat(c);
-    if (v < 0) {
+    if (!isFinite(v) || v < 0) {
         v = 0;
     } else if (v > 5) {
         v = 5;


### PR DESCRIPTION
## Summary

Grouped low-severity defensive fixes across the SkyAware frontend for security hardening.

## Changes

- **`script.js`**: `restrictUrlRequest` — add `isFinite()` check to prevent `NaN` from being stored in `localStorage`
- **`script.js`**: `flag_image` — validate filename pattern (`/^[a-zA-Z0-9_-]+\.png$/`) before setting `img src`, preventing path traversal if data source changes
- **`script.js`**: Altitude table cell — use DOM manipulation (`createElement`/`textContent`) instead of `innerHTML`
- **`formatter.js`**: Add `format_altitude_text()` and `format_vert_rate_triangle()` helpers that return plain text without HTML

## Deferred

- CSRF protection on AJAX fetches — requires server-side changes (SameSite cookies, Origin checks)

Fixes #310