### PR TITLE
Add emergency status banner from ADS-B decoded emergency field

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -722,10 +722,18 @@
 										Tracking Information
 									</div>
 								</div>
-								<div class="infoBlockSection">
-									<div class="infoRowLine">
-										<div class="infoHeading infoRowFluid fourColumnSection1">
-											<span title="Data source for the reported aircraft data (e.g., ADS-B, MLAT, Other Mode S)">Source</span>:
+							<div class="infoBlockSection">
+								<div id="selected_emergency_row" class="infoRowLine hidden">
+									<div class="infoHeading infoRowFluid fourColumnSection1">
+										<span title="Emergency/priority status reported by the aircraft via ADS-B.">Emergency</span>:
+									</div>
+									<div class="infoData infoRowFluid fourColumnSection2">
+										<span id="selected_emergency"></span>
+									</div>
+								</div>
+								<div class="infoRowLine">
+									<div class="infoHeading infoRowFluid fourColumnSection1">
+										<span title="Data source for the reported aircraft data (e.g., ADS-B, MLAT, Other Mode S)">Source</span>:
 										</div>
 										<div class="infoData infoRowFluid fourColumnSection2">
 											<span id="selected_source">n/a</span>

--- a/public_html/planeObject.js
+++ b/public_html/planeObject.js
@@ -85,6 +85,8 @@ function PlaneObject(icao) {
         this.typeDescription = null;
         this.wtc = null;
 
+        this.emergency = null;
+
         this.heard_on_1090 = false;
         this.heard_on_978 = false;
         this.heard_on_tisb = false;
@@ -344,6 +346,10 @@ PlaneObject.prototype.getDataSource = function() {
 };
 
 PlaneObject.prototype.getMarkerColor = function() {
+        // ADS-B emergency field overrides everything
+        if (this.emergency && this.emergency !== 'none' && EmergencyStatus[this.emergency])
+                return EmergencyStatus[this.emergency].markerColor;
+
         // Emergency squawks override everything else
         if (this.squawk in SpecialSquawks)
                 return SpecialSquawks[this.squawk].markerColor;
@@ -581,7 +587,8 @@ PlaneObject.prototype.updateData = function(receiver_timestamp, data, receiver_s
                       "roll", "nav_heading", "nav_modes",
                       "nac_p", "nac_v", "nic_baro", "sil_type", "sil",
                       "nav_qnh", "baro_rate", "geom_rate", "rc",
-                      "squawk", "category", "version", "uat_version"];
+                      "squawk", "category", "version", "uat_version",
+                      "emergency"];
 
         for (var i = 0; i < fields.length; ++i) {
                 if (fields[i] in data) {

--- a/public_html/script.js
+++ b/public_html/script.js
@@ -27,6 +27,15 @@ var SpecialSquawks = {
         '7700' : { cssClass: 'squawk7700', markerColor: 'rgb(255, 255, 0)', text: 'General Emergency' }
 };
 
+var EmergencyStatus = {
+        'general':   { cssClass: 'emergency_general',   markerColor: 'rgb(255, 255, 0)',   text: 'General Emergency' },
+        'lifeguard': { cssClass: 'emergency_lifeguard', markerColor: 'rgb(255, 140, 0)',   text: 'Medical Emergency (Lifeguard)' },
+        'minfuel':   { cssClass: 'emergency_minfuel',   markerColor: 'rgb(255, 165, 0)',   text: 'Minimum Fuel' },
+        'nordo':     { cssClass: 'emergency_nordo',     markerColor: 'rgb(0, 255, 255)',   text: 'No Communications' },
+        'unlawful':  { cssClass: 'emergency_unlawful',  markerColor: 'rgb(255, 85, 85)',   text: 'Unlawful Interference' },
+        'downed':    { cssClass: 'emergency_downed',    markerColor: 'rgb(255, 0, 0)',     text: 'Downed Aircraft' }
+};
+
 // Get current map settings
 var CenterLat, CenterLon, ZoomLvl, MapType, SiteCirclesCount, SiteCirclesBaseDistance, SiteCirclesInterval;
 
@@ -1382,6 +1391,13 @@ function refreshSelected() {
                 $('#selected_squawk').text(selected.squawk);
         }
 
+        if (selected.emergency && selected.emergency !== 'none' && EmergencyStatus[selected.emergency]) {
+                $('#selected_emergency_row').removeClass('hidden');
+                $('#selected_emergency').text(EmergencyStatus[selected.emergency].text);
+        } else {
+                $('#selected_emergency_row').addClass('hidden');
+        }
+
         $('#selected_speed').text(format_speed_long(selected.gs, DisplayUnits));
         $('#selected_ias').text(format_speed_long(selected.ias, DisplayUnits));
         $('#selected_tas').text(format_speed_long(selected.tas, DisplayUnits));
@@ -1714,6 +1730,11 @@ function refreshTableInfo() {
 
                         if (tableplane.squawk in SpecialSquawks) {
                                 classes = classes + " " + SpecialSquawks[tableplane.squawk].cssClass;
+                                show_squawk_warning = true;
+                        }
+
+                        if (tableplane.emergency && tableplane.emergency !== 'none' && EmergencyStatus[tableplane.emergency]) {
+                                classes = classes + " " + EmergencyStatus[tableplane.emergency].cssClass;
                                 show_squawk_warning = true;
                         }
 

--- a/public_html/style.css
+++ b/public_html/style.css
@@ -355,6 +355,36 @@ div#loader {
     background-color: #ffff00;
 }
 
+.emergency_general {
+    font-weight: bold;
+    background-color: #ffff00;
+}
+
+.emergency_lifeguard {
+    font-weight: bold;
+    background-color: #ff8c00;
+}
+
+.emergency_minfuel {
+    font-weight: bold;
+    background-color: #ffa500;
+}
+
+.emergency_nordo {
+    font-weight: bold;
+    background-color: #00ffff;
+}
+
+.emergency_unlawful {
+    font-weight: bold;
+    background-color: #ff5555;
+}
+
+.emergency_downed {
+    font-weight: bold;
+    background-color: #ff0000;
+}
+
 .selected {
     background-color: #dddddd;
 }


### PR DESCRIPTION
## Summary

Surfaces the `emergency` field from `aircraft.json` in the UI. The C backend already decodes 7 emergency states from ADS-B Type 28/1 and Type 29/0 messages, but the frontend was ignoring them — only detecting emergencies via squawk codes 7500/7600/7700.

Fixes #313

## Changes

- **EmergencyStatus lookup object** in `script.js` — maps emergency strings to CSS class, marker color, and display text
- **planeObject.js** — reads `emergency` field in `updateData()`, extends `getMarkerColor()` to use ADS-B emergency (priority over squawk)
- **Table row highlighting** — checks `plane.emergency` in addition to squawk, applies CSS class and sets warning flag
- **Detail panel** — adds emergency row to Tracking Information section, populated when emergency is active
- **CSS classes** — 6 new classes for each emergency type (general, lifeguard, minfuel, nordo, unlawful, downed)

## What stays the same

- Existing squawk-based `SpecialSquawks` system continues to work
- Global `SpecialSquawkWarning` banner continues to show for squawk 7x00
- JSON output format unchanged

## Testing

- Existing squawk alerts (7500/7600/7700) still work
- Aircraft with `emergency: "lifeguard"` in JSON shows orange marker and table highlight
- Selected aircraft panel shows the emergency text
