### PR TITLE
Makefile: probe for -Wformat-signedness instead of assuming it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,15 @@ PROGNAME=dump1090
 DUMP1090_VERSION ?= unknown
 
 CFLAGS ?= -O3 -g
-DUMP1090_CFLAGS := -std=c11 -fno-common -Wall -Wmissing-declarations -Werror -Wformat-signedness -W
+DUMP1090_CFLAGS := -std=c11 -fno-common -Wall -Wmissing-declarations -Werror -W
+
+# -Wformat-signedness is a GCC extension. clang does not implement it and
+# rejects it via -Wunknown-warning-option, which -Werror above turns into a
+# hard build failure. Probe for it so GCC builds keep the warning.
+HAVE_FORMAT_SIGNEDNESS := $(shell $(CC) -Werror -Wformat-signedness -x c -c /dev/null -o /dev/null 2>/dev/null && echo yes)
+ifeq ($(HAVE_FORMAT_SIGNEDNESS),yes)
+  DUMP1090_CFLAGS += -Wformat-signedness
+endif
 DUMP1090_CPPFLAGS := -I. -D_POSIX_C_SOURCE=200112L -DMODES_DUMP1090_VERSION=\"$(DUMP1090_VERSION)\" -DMODES_DUMP1090_VARIANT=\"dump1090-fa\"
 
 LIBS = -lpthread -lm


### PR DESCRIPTION
`-Wformat-signedness` is a GCC extension. clang does not implement it and rejects it via `-Wunknown-warning-option`. Because `DUMP1090_CFLAGS` also contains `-Werror`, that rejection is fatal, so the build dies on the very first compiler invocation — before any source file is read:

```
error: unknown warning option '-Wformat-signedness' [-Werror,-Wunknown-warning-option]
```

The practical effect is that dump1090 cannot be built anywhere clang is the system compiler, macOS in particular. This is the first thing anyone hits there, and it is unrelated to the missing-`pkg-config` and dependency problems reported in #216.

### Change

Probe the compiler for the flag and add it only when it is accepted:

```make
HAVE_FORMAT_SIGNEDNESS := $(shell $(CC) -Werror -Wformat-signedness -x c -c /dev/null -o /dev/null 2>/dev/null && echo yes)
ifeq ($(HAVE_FORMAT_SIGNEDNESS),yes)
  DUMP1090_CFLAGS += -Wformat-signedness
endif
```

The probe itself uses `-Werror` so that clang's warning-level rejection is correctly detected as "unsupported".

I deliberately avoided just deleting the flag: that would fix clang at the cost of silently dropping real format-signedness warning coverage from every GCC build. This keeps GCC behaviour byte-for-byte identical.

### Testing

- **macOS 12.6, Apple clang, x86_64** — `make clean && make` now completes with exit 0 and zero compiler diagnostics. Probe evaluates empty, flag omitted. `dump1090`, `view1090` and `starch-benchmark` all link, and `dump1090 --net-only --write-json` starts, binds ports 30001–30005 + 30104, and writes valid `aircraft.json` / `receiver.json`.
- **Compiler that accepts the flag** — verified via a stub `CC` that the probe resolves to `yes` and `-Wformat-signedness` is appended, so GCC builds are unaffected.

I do not have a GCC/Linux box to hand, so a second pair of eyes on the positive branch would be welcome — though CI should cover it.

Branched from `master` at v11.1 (0339a57).
